### PR TITLE
use CopyDir in _copyDir shortcut

### DIFF
--- a/src/Task/FileSystem/loadShortcuts.php
+++ b/src/Task/FileSystem/loadShortcuts.php
@@ -10,7 +10,7 @@ trait loadShortcuts
      */
     protected function _copyDir($src, $dst)
     {
-        return (new CleanDir($src, $dst))->run();
+        return (new CopyDir($src, $dst))->run();
     }
 
     /**


### PR DESCRIPTION
Fixes #103 (now without handy-dandy GitHub function on the correct base...)