### PR TITLE
Adding default value option to the Configuration trait

### DIFF
--- a/src/Common/Configuration.php
+++ b/src/Common/Configuration.php
@@ -10,8 +10,8 @@ trait Configuration
         Config::set(__CLASS__.".$key", $value);
     }
 
-    protected function getConfigValue($key)
+    protected function getConfigValue($key, $default = null)
     {
-        return Config::get(__CLASS__.".$key");
+        return Config::get(__CLASS__.".$key", $default);
     }
 } 


### PR DESCRIPTION
With this modification the users of the `Robo\Common\Configuration` trait can now specify a default value to use, if none is set.