### PR TITLE
Bugfix/same configuration key overwrites other class

### DIFF
--- a/src/Common/Configuration.php
+++ b/src/Common/Configuration.php
@@ -5,13 +5,18 @@ use Robo\Config;
 
 trait Configuration
 {
+    private static function getClassKey($key)
+    {
+        return sprintf('%s.%s', get_called_class(), $key);
+    }
+
     public static function configure($key, $value)
     {
-        Config::set(__CLASS__.".$key", $value);
+        Config::set(static::getClassKey($key), $value);
     }
 
     protected function getConfigValue($key, $default = null)
     {
-        return Config::get(__CLASS__.".$key", $default);
+        return Config::get(static::getClassKey($key), $default);
     }
 } 

--- a/tests/unit/ConfigurationTest.php
+++ b/tests/unit/ConfigurationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace unit;
+
+use Robo\Task\BaseTask;
+
+class ConfigurationTest extends \Codeception\TestCase\Test
+{
+    public function testDifferentTasksCanHaveSameConfigKeys()
+    {
+        ConfigurationTestTaskA::configure('key', 'value-a');
+        ConfigurationTestTaskB::configure('key', 'value-b');
+
+        $taskA = new ConfigurationTestTaskA();
+        verify($taskA->run())->equals('value-a');
+
+        $taskB = new ConfigurationTestTaskB();
+        verify($taskB->run())->equals('value-b');
+    }
+
+}
+
+class ConfigurationTestTaskA extends BaseTask
+{
+    public function run()
+    {
+        return $this->getConfigValue('key');
+    }
+}
+
+class ConfigurationTestTaskB extends BaseTask
+{
+    public function run()
+    {
+        return $this->getConfigValue('key');
+    }
+}


### PR DESCRIPTION
In Configuration trait, `__CLASS__` is used to prefix the key. But:

> When used in a trait method, `__CLASS__` is the name of the class the trait is used in.

This results in `__CLASS__` always being  `Task\BaseTask`, regardless of the actual task.
This PR fixes this (and adds a test ;).