### PR TITLE
Fix wrong variable name at docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ class RoboFile extends \Robo\Tasks
             ->run();
 
        // running Selenium server in background
-        $this->taskExec('java -jar '.$pathToSelenium)
+        $this->taskExec('java -jar ' . $seleniumPath)
             ->background()
             ->run();
 


### PR DESCRIPTION
The variable was called:

```
     function testAcceptance($seleniumPath = '~/selenium-server-standalone-2.39.0.jar')
```

At line 61 while it was called $pathToSelenium in the line that I'm modifying.