### PR TITLE
Fail with exception so the task run exits with > 0

### DIFF
--- a/src/Task/Development/SemVer.php
+++ b/src/Task/Development/SemVer.php
@@ -138,7 +138,10 @@ class SemVer implements TaskInterface
     {
         extract($this->version);
         $semver = sprintf(self::SEMVER, $major, $minor, $patch, $special, $metadata);
-        return file_put_contents($this->path, $semver);
+        if (is_writeable($this->path) === false || file_put_contents($this->path, $semver) === false) {
+            throw new TaskException($this, 'Failed to write semver file.');
+        }
+        return true;
     }
 
     protected function parse()

--- a/tests/unit/SemVerTest.php
+++ b/tests/unit/SemVerTest.php
@@ -28,4 +28,4 @@ class SemVerTest extends \Codeception\TestCase\Test
             ->increment('major')
             ->run();
     }
-} 
+}

--- a/tests/unit/SemVerTest.php
+++ b/tests/unit/SemVerTest.php
@@ -17,4 +17,15 @@ class SemVerTest extends \Codeception\TestCase\Test
         verify($res->getMessage())->equals('v1.0.1-RC.1');
         $semver->verifyInvoked('dump');
     }
+
+    public function testThrowsExceptionWhenSemverFileNotWriteable()
+    {
+        \PHPUnit_Framework_TestCase::setExpectedExceptionRegExp(
+            'Robo\Exception\TaskException',
+            '/Failed to write semver file./'
+        );
+        $this->taskSemVer('/.semver')
+            ->increment('major')
+            ->run();
+    }
 } 


### PR DESCRIPTION
Had the case where a non writeable .semver file didn't cause the whole task run to exit with an error > 0.