### PR TITLE
Allow to set custom name of coverage file raw name.

### DIFF
--- a/src/Task/Testing/Codecept.php
+++ b/src/Task/Testing/Codecept.php
@@ -139,13 +139,14 @@ class Codecept extends BaseTask implements CommandInterface, PrintedInterface
     }
 
     /**
-     * turn on collecting code coverage
+     * collect codecoverage in raw format. You may pass name of cov file to save results
      *
+     * @param string $cov
      * @return $this
      */
-    public function coverage()
+    public function coverage($cov = null)
     {
-        $this->option("coverage");
+        $this->option("coverage", $cov);
         return $this;
     }
 


### PR DESCRIPTION
As is noted on Codeception, --coverage option is allowed to set custom
file name.

I looked at source code of Codeception project, and this should work if not other --coverage-xxx is included.