### PR TITLE
test Task ReplaceInFile for multiple strings in file

### DIFF
--- a/src/Task/File/Replace.php
+++ b/src/Task/File/Replace.php
@@ -23,6 +23,11 @@ use Robo\Task\BaseTask;
  *  ->regex('~^service:~')
  *  ->to('services:')
  *  ->run();
+ *
+ * $this->taskReplaceInFile('box/robo.txt')
+ *  ->from(array('##dbname##', 'robo'))
+ *  ->to(array('##dbhost## ', 'localhost'))
+ *  ->run();
  * ?>
  * ```
  *

--- a/tests/cli/WriteFileCest.php
+++ b/tests/cli/WriteFileCest.php
@@ -64,5 +64,15 @@ HERE
         $I->seeFileContentsEqual('B');
         
     }
+
+    public function replaceMultipleInFile(CliGuy $I)
+    {
+        $I->taskReplaceInFile('box/robo.txt')
+            ->from(array('HELLO', 'ROBO'))
+            ->to(array('Hello ', 'robo.li!'))
+            ->run();
+        $I->seeFileFound('box/robo.txt');
+        $I->seeFileContentsEqual('Hello robo.li!');
+    }
 }
 


### PR DESCRIPTION
I noticed that the current implementation allows to supply an array of arguments for to and from, so that IO access to files can be minimized. I think this is a good feature, but I noticed that there is no test for that.
So I created a little test and a sentence in the documentation for this behaviour.

Best regards Philipp