### PR TITLE
Update php server eamples

### DIFF
--- a/docs/tasks/Development.md
+++ b/docs/tasks/Development.md
@@ -166,17 +166,17 @@ Runs PHP server and stops it when task finishes.
 ``` php
 <?php
 // run server in /public directory
-$this->taskPhpServer(8000)
+$this->taskServer(8000)
  ->dir('public')
  ->run();
 
 // run with IP 0.0.0.0
-$this->taskPhpServer(8000)
+$this->taskServer(8000)
  ->host('0.0.0.0')
  ->run();
 
 // execute server in background
-$this->taskPhpServer(8000)
+$this->taskServer(8000)
  ->background()
  ->run();
 ?>

--- a/src/Task/Development/PhpServer.php
+++ b/src/Task/Development/PhpServer.php
@@ -9,17 +9,17 @@ use Robo\Task\Base\Exec;
  * ``` php
  * <?php
  * // run server in /public directory
- * $this->taskPhpServer(8000)
+ * $this->taskServer(8000)
  *  ->dir('public')
  *  ->run();
  *
  * // run with IP 0.0.0.0
- * $this->taskPhpServer(8000)
+ * $this->taskServer(8000)
  *  ->host('0.0.0.0')
  *  ->run();
  *
  * // execute server in background
- * $this->taskPhpServer(8000)
+ * $this->taskServer(8000)
  *  ->background()
  *  ->run();
  * ?>


### PR DESCRIPTION
I noticed that in the docs and on the website the code examples for the php server task refer to a method "$this->taskPHPServer" that does not exist, I believe that these references should be updated to "taskServer" and that is reflected in this pull request.