### PR TITLE
phpunit: replace log-xml with log-junit 

### DIFF
--- a/src/Task/Testing/PHPUnit.php
+++ b/src/Task/Testing/PHPUnit.php
@@ -75,14 +75,14 @@ class PHPUnit extends BaseTask implements CommandInterface, PrintedInterface
     }
 
     /**
-     * adds `log-xml` option
+     * adds `log-junit` option
      *
      * @param string $file
      * @return $this
      */
     public function xml($file = null)
     {
-        $this->option("log-xml", $file);
+        $this->option("log-junit", $file);
         return $this;
     }
 

--- a/tests/unit/PHPUnitTest.php
+++ b/tests/unit/PHPUnitTest.php
@@ -32,9 +32,9 @@ class PHPUnitTest extends \Codeception\TestCase\Test
             ->group('important')
             ->xml('result.xml')
             ->debug();
-        verify($task->getCommand())->equals('phpunit --bootstrap bootstrap.php --filter Model --group important --log-xml result.xml --debug');
+        verify($task->getCommand())->equals('phpunit --bootstrap bootstrap.php --filter Model --group important --log-junit result.xml --debug');
         $task->run();
-        $this->phpunit->verifyInvoked('executeCommand', ['phpunit --bootstrap bootstrap.php --filter Model --group important --log-xml result.xml --debug']);
+        $this->phpunit->verifyInvoked('executeCommand', ['phpunit --bootstrap bootstrap.php --filter Model --group important --log-junit result.xml --debug']);
     }
 
 }


### PR DESCRIPTION
Hi,

--log-xml has been replaced  with --log-junit in 3.4 and removed in 3.5.

vkunz
