### PR TITLE
Fixing concat, it breaks some files if there is no new line.

### DIFF
--- a/src/Task/File/Concat.php
+++ b/src/Task/File/Concat.php
@@ -73,7 +73,7 @@ class Concat extends BaseTask
                     return Result::error($this, sprintf('File %s not found', $file));
                 }
 
-                $dump .= file_get_contents($file);
+                $dump .= file_get_contents($file) . "\n";
             }
         }
 

--- a/tests/cli/ConcatCept.php
+++ b/tests/cli/ConcatCept.php
@@ -6,4 +6,4 @@ $I->taskConcat(['a.txt', 'b.txt'])
     ->to('merged.txt')
     ->run();
 $I->seeFileFound('merged.txt');
-$I->seeFileContentsEqual('AB');
+$I->seeFileContentsEqual("A\nB\n");


### PR DESCRIPTION
When concatenating JS files that are NOT minified for development purpose for example that contain comments /*..*/ it will cause syntax errors in the concatenated file.