### PR TITLE
Fix error in array name at documentation

### DIFF
--- a/docs/started.md
+++ b/docs/started.md
@@ -87,7 +87,7 @@ To define command options you should define last method parameter as an associat
 <?php
     function hello($opts = ['silent' => false])
     {
-        if (!$opt['silent']) $this->say("Hello, world");
+        if (!$opts['silent']) $this->say("Hello, world");
     }
 ?>
 ```


### PR DESCRIPTION
Fixes a wrong name of a variable in the documentation. Is wrong because in previous line is called `$opts` and in the present line is called `$opt` instead