### PR TITLE
Fix unit-tests on windows

### DIFF
--- a/src/Common/ExecCommand.php
+++ b/src/Common/ExecCommand.php
@@ -71,6 +71,6 @@ trait ExecCommand
         }
         $this->stopTimer();
 
-		return new Result($this, $process->getExitCode(), $process->getOutput(), ['time' => $this->getExecutionTime()]);
+        return new Result($this, $process->getExitCode(), $process->getOutput(), ['time' => $this->getExecutionTime()]);
     }
 } 

--- a/src/Task/Gulp/Base.php
+++ b/src/Task/Gulp/Base.php
@@ -4,6 +4,7 @@ namespace Robo\Task\Gulp;
 
 use Robo\Task\BaseTask;
 use Robo\Exception\TaskException;
+use Symfony\Component\Process\ProcessUtils;
 
 abstract class Base extends BaseTask
 {
@@ -73,6 +74,6 @@ abstract class Base extends BaseTask
 
     public function getCommand()
     {
-        return "{$this->command} " . escapeshellarg($this->task) . "{$this->arguments}";
+        return "{$this->command} " . ProcessUtils::escapeArgument($this->task) . "{$this->arguments}";
     }
 }

--- a/tests/unit/CodeceptionTest.php
+++ b/tests/unit/CodeceptionTest.php
@@ -9,8 +9,15 @@ class CodeceptionTest extends \Codeception\TestCase\Test
      */
     protected $codecept;
 
+    /**
+     * @var string
+     */
+    protected $command;
+
     protected function _before()
     {
+        $isWindows = defined('PHP_WINDOWS_VERSION_MAJOR');
+        $this->command = $isWindows ? 'call vendor/bin/codecept run' : 'vendor/bin/codecept run';
         $this->codecept = test::double('Robo\Task\Testing\Codecept', [
             'executeCommand' => null,
             'getOutput' => new \Symfony\Component\Console\Output\NullOutput()
@@ -20,14 +27,14 @@ class CodeceptionTest extends \Codeception\TestCase\Test
     // tests
     public function testCodeceptionCommand()
     {
-        verify($this->taskCodecept()->getCommand())->equals('vendor/bin/codecept run');
+        verify($this->taskCodecept()->getCommand())->equals($this->command);
         verify(trim($this->taskCodecept('codecept.phar')->getCommand()))->equals('codecept.phar run');
     }
 
     public function testCodeceptionRun()
     {
         $this->taskCodecept()->run();
-        $this->codecept->verifyInvoked('executeCommand', ['vendor/bin/codecept run']);
+        $this->codecept->verifyInvoked('executeCommand', [$this->command]);
     }
 
     public function testCodeceptOptions()

--- a/tests/unit/GulpTest.php
+++ b/tests/unit/GulpTest.php
@@ -16,42 +16,71 @@ class GulpTest extends \Codeception\TestCase\Test
             'getOutput' => new \Symfony\Component\Console\Output\NullOutput()
         ]);
     }
+
     // tests
     public function testGulpRun()
     {
-        verify(
-            $this->taskGulpRun('default','gulp')->getCommand()
-        )->equals('gulp \'default\'');
-        
-        verify(
-            $this->taskGulpRun('another','gulp')->getCommand()
-        )->equals('gulp \'another\'');
+        $isWindows = defined('PHP_WINDOWS_VERSION_MAJOR');
 
-        verify(
-            $this->taskGulpRun('anotherWith wired!("\') Chars','gulp')->getCommand()
-        )->equals("gulp 'anotherWith wired!(\"'\\'') Chars'");
+        if ($isWindows) {
+            verify(
+                $this->taskGulpRun('default','gulp')->getCommand()
+            )->equals('gulp "default"');
+            
+            verify(
+                $this->taskGulpRun('another','gulp')->getCommand()
+            )->equals('gulp "another"');
 
+            verify(
+                $this->taskGulpRun('anotherWith weired!("\') Chars','gulp')->getCommand()
+            )->equals('gulp "anotherWith weired!(\"\') Chars"');
 
-        verify(
-            $this->taskGulpRun('default','gulp')->silent()->getCommand()
-        )->equals('gulp \'default\' --silent');
+            verify(
+                $this->taskGulpRun('default','gulp')->silent()->getCommand()
+            )->equals('gulp "default" --silent');
 
-        verify(
-            $this->taskGulpRun('default','gulp')->noColor()->getCommand()
-        )->equals('gulp \'default\' --no-color');
+            verify(
+                $this->taskGulpRun('default','gulp')->noColor()->getCommand()
+            )->equals('gulp "default" --no-color');
 
-        verify(
-            $this->taskGulpRun('default','gulp')->color()->getCommand()
-        )->equals('gulp \'default\' --color');
+            verify(
+                $this->taskGulpRun('default','gulp')->color()->getCommand()
+            )->equals('gulp "default" --color');
 
-        verify(
-            $this->taskGulpRun('default','gulp')->simple()->getCommand()
-        )->equals('gulp \'default\' --tasks-simple');
+            verify(
+                $this->taskGulpRun('default','gulp')->simple()->getCommand()
+            )->equals('gulp "default" --tasks-simple');
 
+        } else {
 
+            verify(
+                $this->taskGulpRun('default','gulp')->getCommand()
+            )->equals('gulp \'default\'');
+            
+            verify(
+                $this->taskGulpRun('another','gulp')->getCommand()
+            )->equals('gulp \'another\'');
 
+            verify(
+                $this->taskGulpRun('anotherWith weired!("\') Chars','gulp')->getCommand()
+            )->equals("gulp 'anotherWith weired!(\"'\\'') Chars'");
 
+            verify(
+                $this->taskGulpRun('default','gulp')->silent()->getCommand()
+            )->equals('gulp \'default\' --silent');
 
+            verify(
+                $this->taskGulpRun('default','gulp')->noColor()->getCommand()
+            )->equals('gulp \'default\' --no-color');
+
+            verify(
+                $this->taskGulpRun('default','gulp')->color()->getCommand()
+            )->equals('gulp \'default\' --color');
+
+            verify(
+                $this->taskGulpRun('default','gulp')->simple()->getCommand()
+            )->equals('gulp \'default\' --tasks-simple');
+        }
     }
 
 }

--- a/tests/unit/PHPUnitTest.php
+++ b/tests/unit/PHPUnitTest.php
@@ -20,8 +20,11 @@ class PHPUnitTest extends \Codeception\TestCase\Test
     // tests
     public function testPhpUnitRun()
     {
+        $isWindows = defined('PHP_WINDOWS_VERSION_MAJOR');
+        $command = $isWindows ? 'call vendor/bin/phpunit' : 'vendor/bin/phpunit';
+        
         $this->taskPHPUnit()->run();
-        $this->phpunit->verifyInvoked('executeCommand', ['vendor/bin/phpunit']);
+        $this->phpunit->verifyInvoked('executeCommand', [$command]);
     }
 
     public function testPHPUnitCommand()


### PR DESCRIPTION
This should fix issue #129.

I found out that one testcase in the gulp test was testing a part where escapeshellarg from php is used for escaping the name of the task. In windows it's a bit complicated to escape double quotes on the command line (been there ..) So I used the symfony utility which behaves correctly on windows and unix escaping double quotes in commands.

The other fixes were just prepending "call" to batch files and changing from single-quotes to double-quotes

best regards
Philipp