### PR TITLE
PhpServer: Wrap `php` command with `exec`

### DIFF
--- a/src/Task/Development/PhpServer.php
+++ b/src/Task/Development/PhpServer.php
@@ -29,7 +29,7 @@ class PhpServer extends Exec
 {
     protected $port;
     protected $host = '127.0.0.1';
-    protected $command = 'php -S %s:%d ';
+    protected $command = 'exec php -S %s:%d ';
 
     public function __construct($port)
     {

--- a/src/Task/Development/PhpServer.php
+++ b/src/Task/Development/PhpServer.php
@@ -29,11 +29,15 @@ class PhpServer extends Exec
 {
     protected $port;
     protected $host = '127.0.0.1';
-    protected $command = 'exec php -S %s:%d ';
+    protected $command = 'php -S %s:%d ';
 
     public function __construct($port)
     {
         $this->port = $port;
+
+        if (strtolower(PHP_OS) === 'linux') {
+            $this->command = 'exec php -S %s:%d';
+        }
     }
 
     public function host($host)

--- a/src/Task/Development/PhpServer.php
+++ b/src/Task/Development/PhpServer.php
@@ -36,7 +36,7 @@ class PhpServer extends Exec
         $this->port = $port;
 
         if (strtolower(PHP_OS) === 'linux') {
-            $this->command = 'exec php -S %s:%d';
+            $this->command = 'exec php -S %s:%d ';
         }
     }
 

--- a/tests/unit/PHPServerTest.php
+++ b/tests/unit/PHPServerTest.php
@@ -34,11 +34,18 @@ class PHPServerTest extends \Codeception\TestCase\Test
 
     public function testServerCommand()
     {
+        if (strtolower(PHP_OS) === 'linux') {
+            $expectedCommand = 'exec php -S 127.0.0.1:8000 -t web';
+        } else {
+            $expectedCommand = 'php -S 127.0.0.1:8000 -t web';
+        }
+
         verify(
             $this->taskServer('8000')
+                ->host('127.0.0.1')
                 ->dir('web')
                 ->getCommand()
-        )->equals('exec php -S 127.0.0.1:8000 -t web');
+        )->equals($expectedCommand);
     }
 
 }

--- a/tests/unit/PHPServerTest.php
+++ b/tests/unit/PHPServerTest.php
@@ -38,7 +38,7 @@ class PHPServerTest extends \Codeception\TestCase\Test
             $this->taskServer('8000')
                 ->dir('web')
                 ->getCommand()
-        )->equals('php -S 127.0.0.1:8000 -t web');
+        )->equals('exec php -S 127.0.0.1:8000 -t web');
     }
 
 }


### PR DESCRIPTION
Wrap `php` command with `exec` to prevent detached PHP server process on e.g. Debian after stopping the background task.

On Debian, the PHP server process currently does not get killed.
The server gets startet correctly:
```
vagrant   4233  pts/0    Ss   09:05   0:00  |       \_ -bash
vagrant   5936  pts/0    S+   10:43   0:00  |           \_ php bin/robo server
vagrant   5937  pts/0    S+   10:43   0:00  |               \_ sh -c php -S 0.0.0.0:8000 -t public
vagrant   5938  pts/0    S+   10:43   0:00  |                   \_ php -S 0.0.0.0:8000 -t public
```

But after finishing the task and stopping the process, the actual PHP server process is still running:
```
vagrant   5938  pts/0    S    10:43   0:00 php -S 0.0.0.0:8000 -t public
```

In this example, only the PID 5937 was killed, not the server itself 5938.
Wrapping the `php` call with `exec` fixes that issue.

Best
Fabian