### PR TITLE
Fix watch example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ Using `watch` task so you can use it for running tests or building assets.
 ``` php
 <?php
 class RoboFile extends \Robo\Tasks {
-    use \Robo\Task\Watch;
 
     function watchComposer()
     {


### PR DESCRIPTION
With the latest version using the task traits is no longer needed. Fixed the watch example as it was still using old code.