### PR TITLE
Fix wrong option to skip groups

### DIFF
--- a/src/Task/Testing/Codecept.php
+++ b/src/Task/Testing/Codecept.php
@@ -74,7 +74,7 @@ class Codecept extends BaseTask implements CommandInterface, PrintedInterface
 
     public function excludeGroup($group)
     {
-        $this->option("exclude-group", $group);
+        $this->option("skip-group", $group);
         return $this;
     }
 

--- a/tests/unit/CodeceptionTest.php
+++ b/tests/unit/CodeceptionTest.php
@@ -58,7 +58,7 @@ class CodeceptionTest extends \Codeception\TestCase\Test
 
         verify($this->taskCodecept()->debug()->getCommand())->contains(' --debug');
         verify($this->taskCodecept()->silent()->getCommand())->contains(' --silent');
-        verify($this->taskCodecept()->excludeGroup('g')->getCommand())->contains(' --exclude-group g');
+        verify($this->taskCodecept()->excludeGroup('g')->getCommand())->contains(' --skip-group g');
         verify($this->taskCodecept()->tap()->getCommand())->contains('--tap');
         verify($this->taskCodecept()->json()->getCommand())->contains('--json');
     }


### PR DESCRIPTION
There was a mistake in the skip group option:

![screen shot 2015-06-16 at 17 08 06](https://cloud.githubusercontent.com/assets/1375475/8186244/673b6432-1449-11e5-92f9-0357bc2ebcba.png)

As you see, the real name of the option is:

![screen shot 2015-06-16 at 17 09 31](https://cloud.githubusercontent.com/assets/1375475/8186276/9848984c-1449-11e5-94e2-4a8a6fa32426.png)

This pull fixes the issue