### PR TITLE
Fixed capitalisation of task info output

### DIFF
--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -110,7 +110,7 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface
     {
         if ($this->background && $this->process->isRunning()) {
             $this->process->stop();
-            $this->printTaskInfo("stopped <info>".$this->getCommand()."</info>");
+            $this->printTaskInfo("Stopped <info>".$this->getCommand()."</info>");
         }
     }
 
@@ -118,7 +118,7 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface
     {
         $command = $this->getCommand();
         $dir = $this->workingDirectory ? " in " . $this->workingDirectory : "";
-        $this->printTaskInfo("running <info>{$command}</info>$dir");
+        $this->printTaskInfo("Running <info>{$command}</info>$dir");
         $this->process = new Process($command);
         $this->process->setTimeout($this->timeout);
         $this->process->setIdleTimeout($this->idleTimeout);

--- a/src/Task/Base/Watch.php
+++ b/src/Task/Base/Watch.php
@@ -51,7 +51,7 @@ class Watch extends BaseTask
             $closure->bindTo($this->bindTo);
             foreach ($monitor[0] as $i => $dir) {
                 $watcher->track("fs.$k.$i", $dir, FilesystemEvent::MODIFY);
-                $this->printTaskInfo("watching <info>$dir</info> for changes...");
+                $this->printTaskInfo("Watching <info>$dir</info> for changes...");
                 $watcher->addListener("fs.$k.$i", $closure);
             }
         }

--- a/src/Task/Development/PackPhar.php
+++ b/src/Task/Development/PackPhar.php
@@ -99,12 +99,12 @@ EOF;
 
     public function run()
     {
-        $this->printTaskInfo("creating <info>{$this->filename}</info>");
+        $this->printTaskInfo("Creating <info>{$this->filename}</info>");
         $this->phar->setSignatureAlgorithm(\Phar::SHA1);
         $this->phar->startBuffering();
 
-        $this->printTaskInfo('packing ' . count($this->files) . ' files into phar');
-        
+        $this->printTaskInfo('Packing ' . count($this->files) . ' files into phar');
+
         $progress = new ProgressBar($this->getOutput());
         $progress->start(count($this->files));
         $this->startTimer();

--- a/src/Task/FileSystem/CleanDir.php
+++ b/src/Task/FileSystem/CleanDir.php
@@ -20,7 +20,7 @@ class CleanDir extends BaseDir
     {
         foreach ($this->dirs as $dir) {
             $this->emptyDir($dir);
-            $this->printTaskInfo("cleaned <info>$dir</info>");
+            $this->printTaskInfo("Cleaned <info>$dir</info>");
         }
         return Result::success($this);
     }

--- a/src/Task/FileSystem/DeleteDir.php
+++ b/src/Task/FileSystem/DeleteDir.php
@@ -20,7 +20,7 @@ class DeleteDir extends BaseDir
     {
         foreach ($this->dirs as $dir) {
             $this->fs->remove($dir);
-            $this->printTaskInfo("deleted <info>$dir</info>...");
+            $this->printTaskInfo("Deleted <info>$dir</info>...");
         }
         return Result::success($this);
     }

--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -259,7 +259,7 @@ class Rsync extends BaseTask implements CommandInterface
     public function run()
     {
         $command = $this->getCommand();
-        $this->printTaskInfo("running <info>{$command}</info>");
+        $this->printTaskInfo("Running <info>{$command}</info>");
 
         return $this->executeCommand($command);
     }


### PR DESCRIPTION
The task info outputs couldn't seem to make up their mind if they should be capitalised or not. Symfony's console often uses the paradigm where every first-column item is capitalised, and indented items can be whatever makes sense.