### PR TITLE
Add missing packages error reporting to Minify and Less tasks

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -40,6 +40,14 @@ class Result
         }
     }
 
+    public static function errorMissingPackage(TaskInterface $task, $class, $package)
+    {
+        $messageTpl = 'Class %s not found. Please install %s Composer package';
+        $message = sprintf($messageTpl, $class, $package);
+
+        return self::error($task, $message);
+    }
+
     static function error(TaskInterface $task, $message, $data = [])
     {
         return new self($task, 1, $message, $data);

--- a/src/Task/Assets/Less.php
+++ b/src/Task/Assets/Less.php
@@ -128,6 +128,10 @@ class Less extends BaseTask
      */
     protected function lessphp($file)
     {
+        if (!class_exists('\lessc')) {
+            return Result::errorMissingPackage($this, 'lessc', 'leafo/lessphp');
+        }
+
         $lessCode = file_get_contents($file);
         $less = new \lessc();
         return $less->compile($lessCode);
@@ -141,6 +145,10 @@ class Less extends BaseTask
      */
     protected function less($file)
     {
+        if (!class_exists('\Less_Parser')) {
+            return Result::errorMissingPackage($this, 'Less_Parser', 'oyejorge/less.php');
+        }
+
         $lessCode = file_get_contents($file);
         $parser = new \Less_Parser();
         $parser->parse($lessCode);
@@ -157,8 +165,10 @@ class Less extends BaseTask
         foreach ($this->files as $in => $out) {
             $css = $this->compile($in);
 
-            if (false === $css) {
-                return \Result::error($this, 'Less compilation failed for %s.', $in);
+            if ($css instanceof Result) {
+                return $css;
+            } elseif (false === $css) {
+                return Result::error($this, 'Less compilation failed for %s.', $in);
             }
 
             $dst = $out . '.part';

--- a/src/Task/Assets/Minify.php
+++ b/src/Task/Assets/Minify.php
@@ -149,17 +149,25 @@ class Minify extends BaseTask
     protected function getMinifiedText()
     {
         switch ($this->type) {
-
             case 'css':
+                if (!class_exists('\CssMin')) {
+                    return Result::errorMissingPackage($this, 'CssMin', 'natxet/CssMin');
+                }
+
                 return \CssMin::minify($this->text);
                 break;
 
             case 'js':
+                if (!class_exists('\JSqueeze') && !class_exists('\Patchwork\JSqueeze')) {
+                    return Result::errorMissingPackage($this, 'Patchwork\JSqueeze', 'patchwork/jsqueeze');
+                }
+
                 if (class_exists('\JSqueeze')) {
                     $jsqueeze = new \JSqueeze();
                 } else {
                     $jsqueeze = new \Patchwork\JSqueeze();
                 }
+
                 return $jsqueeze->squeeze(
                     $this->text,
                     $this->squeezeOptions['singleLine'],
@@ -231,7 +239,9 @@ class Minify extends BaseTask
         $size_before = strlen($this->text);
         $minified = $this->getMinifiedText();
 
-        if (false === $minified) {
+        if ($minified instanceof Result) {
+            return $minified;
+        } elseif (false === $minified) {
             return Result::error($this, 'Minification failed.');
         }
 


### PR DESCRIPTION
If required package is not installed, detailed detailed error message will be shown:
```bash
Class lessc not found. Please install leafo/lessphp Composer package
```