### PR TITLE
Fix Replace task always writing to file

### DIFF
--- a/src/Task/File/Replace.php
+++ b/src/Task/File/Replace.php
@@ -62,11 +62,15 @@ class Replace extends BaseTask
         } else {
             $text = str_replace($this->from, $this->to, $text, $count);
         }
-        $res = file_put_contents($this->filename, $text);
-        if ($res === false) {
-            return Result::error($this, "Error writing to file {$this->filename}.");
+        if ($count > 0) {
+            $res = file_put_contents($this->filename, $text);
+            if ($res === false) {
+                return Result::error($this, "Error writing to file {$this->filename}.");
+            }
+            $this->printTaskSuccess("<info>{$this->filename}</info> updated. $count items replaced");
+        } else {
+            $this->printTaskInfo("<info>{$this->filename}</info> unchanged. $count items replaced");
         }
-        $this->printTaskSuccess("<info>{$this->filename}</info> updated. $count items replaced");
         return Result::success($this, '', ['replaced' => $count]);
     }
 }


### PR DESCRIPTION
The Replace task is always writing to file regardless whether any changes were made or not. This can bring the taskrunner into an inifinite loop if a replaced file is being watched.