### PR TITLE
Fix an example in documentation.

### DIFF
--- a/docs/started.md
+++ b/docs/started.md
@@ -293,8 +293,7 @@ Thus you can use this results to check if execution was successful, and use some
 <?php
 class RoboFile
 {
-    use Robo\Output;
-    use Robo\Task\Exec;
+    use Robo\Task\Base\loadShortcuts;
 
     function test()
     {


### PR DESCRIPTION
Hi!

I've noted that example in docs is not relevant, there is no such trait like use Robo\Task\Exec and seems use Robo\Task\Base\loadShortcuts is enough.