### PR TITLE
Added the InputInterface filled with all arguments and options to Robo\Config

### DIFF
--- a/src/Common/IO.php
+++ b/src/Common/IO.php
@@ -25,7 +25,7 @@ trait IO
      */
     protected function getInput()
     {
-        return Config::get('input');
+        return Config::get('input', new ArgvInput());
     }
 
     protected function say($text)

--- a/src/Common/IO.php
+++ b/src/Common/IO.php
@@ -25,7 +25,7 @@ trait IO
      */
     protected function getInput()
     {
-        return new ArgvInput();
+        return Config::get('input');
     }
 
     protected function say($text)

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,17 +1,24 @@
 <?php 
 namespace Robo;
 
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Config
 {
     protected static $config = [
         'output' => null,
+        'input' => null
     ];
 
     public static function setOutput(OutputInterface $output)
     {
         self::$config['output'] = $output;
+    }
+
+    public static function setInput(InputInterface $input)
+    {
+        self::$config['input'] = $input;
     }
 
     public static function get($key, $default = null)

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -75,6 +75,7 @@ class Runner
         Config::setOutput(new ConsoleOutput());
 
         $input = $this->prepareInput($input ? $input : $_SERVER['argv']);
+        Config::setInput($input);
         $app = new Application('Robo', self::VERSION);
 
         if (!$this->loadRoboFile()) {


### PR DESCRIPTION
I needed the full InputInterface, and found out that it's not saved into the Config object. 

With this patch, you can get the input with `$this->getInput()` or `\Robo\Config::get('input')` both directly from the RoboFile. 