### PR TITLE
Allow RoboClass without setting RoboFile.

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -49,6 +49,11 @@ class Runner
 
     protected function loadRoboFile()
     {
+        // In the case the RoboClass is already autoloaded, we do not need any further checks.
+        if (class_exists($this->roboClass)) {
+            return true;
+        }
+        
         if (!file_exists($this->dir)) {
             $this->yell("Path in `{$this->dir}` is invalid, please provide valid absolute path to load Robofile", 40, 'red');
             return false;


### PR DESCRIPTION
When using robo within a script or an autoloaded environment, it is not necessary to provide the exact location of the RoboClass. So it would be nice to make that RoboFile optional.

This way we can do something like this.
```php
$robo = new \Robo\Runner('\MyProject\MyRoboFile');
$robo->execute(array('robo', 'something'));
```