### PR TITLE
Allow Rsync::exclude to accept a list of patterns to exclude.

### DIFF
--- a/src/Common/CommandArguments.php
+++ b/src/Common/CommandArguments.php
@@ -35,10 +35,13 @@ trait CommandArguments
     }
 
     /**
-     * Pass option to executable. Options are prefixed with `--` , value can be provided in second parameter
+     * Pass option to executable. Options are prefixed with `--` , value can be provided in second parameter.
+     *
+     * Option values must be explicitly escaped with escapeshellarg if necessary before being passed to
+     * this function.
      *
      * @param $option
-     * @param null $value
+     * @param string $value
      * @return $this
      */
     public function option($option, $value = null)
@@ -51,5 +54,28 @@ trait CommandArguments
         return $this;
     }
 
+    /**
+     * Pass multiple options to executable. Value can be a string or array.
+     *
+     * Option values should be provided in raw, unescaped form; they are always
+     * escaped via escapeshellarg in this function.
+     *
+     * @param $option
+     * @param string|array $value
+     * @return $this
+     */
+    public function optionList($option, $value = array())
+    {
+        if (is_array($value)) {
+            foreach ($value as $item) {
+                $this->optionList($option, $item);
+            }
+        }
+        else {
+            $this->option($option, escapeshellarg($value));
+        }
 
-} 
+        return $this;
+    }
+
+}

--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -229,16 +229,7 @@ class Rsync extends BaseTask implements CommandInterface
 
     public function exclude($pattern)
     {
-        if (is_array($pattern)) {
-            foreach ($pattern as $item) {
-                $this->exclude($item);
-            }
-        }
-        else {
-            $this->option('exclude', escapeshellarg($pattern));
-        }
-
-        return $this;
+        return $this->optionList(__FUNCTION__, $pattern);
     }
 
     public function excludeFrom($file)
@@ -248,6 +239,16 @@ class Rsync extends BaseTask implements CommandInterface
         }
 
         return $this->option('exclude-from', $file);
+    }
+
+    public function includeFilter($pattern)
+    {
+        return $this->optionList('include', $pattern);
+    }
+
+    public function filter($pattern)
+    {
+        return $this->optionList(__FUNCTION__, $pattern);
     }
 
     public function filesFrom($file)

--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -231,7 +231,7 @@ class Rsync extends BaseTask implements CommandInterface
     {
         if (is_array($pattern)) {
             foreach ($pattern as $item) {
-                $this->option('exclude', escapeshellarg($item));
+                $this->exclude($item);
             }
         }
         else {

--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -224,16 +224,21 @@ class Rsync extends BaseTask implements CommandInterface
      */
     public function excludeVcs()
     {
-        $this->exclude('.git/')
-            ->exclude('.svn/')
-            ->exclude('.hg/');
-
-        return $this;
+        return $this->exclude(['.git/', '.svn/', '.hg/']);
     }
 
     public function exclude($pattern)
     {
-        return $this->option('exclude', escapeshellarg($pattern));
+        if (is_array($pattern)) {
+            foreach ($pattern as $item) {
+                $this->option('exclude', escapeshellarg($item));
+            }
+        }
+        else {
+            $this->option('exclude', escapeshellarg($pattern));
+        }
+
+        return $this;
     }
 
     public function excludeFrom($file)


### PR DESCRIPTION
This PR allows `taskRsync::exclude()` to take an array of patterns, in addition to its traditional parameter value of a single string.

Motivation: sometimes, you might want to call taskRsync with a variable list of locations to exclude.

Before this PR:
```
    $rsync = $this->taskRsync()
      ->fromPath("$tmpDir/drupal-8/")
      ->toPath($webroot)
      ->args('-a', '-v', '-z')
      ->args('--delete');
    foreach ($excludes as $exclude) {
      $rsync->exclude($exclude);
    }
    $rsync->run();
```
After this PR:
```
    $this->taskRsync()
      ->fromPath("$tmpDir/drupal-8/")
      ->toPath($webroot)
      ->args('-a', '-v', '-z')
      ->args('--delete')
      ->exclude($excludes)
      ->run();
```