### PR TITLE
Update the Lurker library dependency to ~1.1@dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/console": "~2.5",
         "symfony/process": "~2.5",
         "symfony/filesystem": "~2.5",
-        "henrikbjorn/lurker": "1.0.*@dev"
+        "henrikbjorn/lurker": "~1.1@dev"
     },
     "require-dev": {
         "patchwork/jsqueeze": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,11 +4,12 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4c146f082ebbabf4f5d4e797db4d52d3",
+    "hash": "f3c3d5e97422b992cfe5313b8ae06136",
+    "content-hash": "937d6cd1a4b1e2a7fbf2a507996da5cb",
     "packages": [
         {
             "name": "henrikbjorn/lurker",
-            "version": "dev-master",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/flint/Lurker.git",


### PR DESCRIPTION
The Lurker library in version ~1.0 has an issue, where sometimes it is impossible to watch directories. I propose updating it to version ~1.1 where I did not encounter this problem.