### PR TITLE
Make testErrorIsHandled unit test pass.

### DIFF
--- a/tests/unit/RunnerTest.php
+++ b/tests/unit/RunnerTest.php
@@ -28,14 +28,33 @@ class RunnerTest extends \Codeception\TestCase\Test
     {
         $tmpLevel = error_reporting();
 
+        // Set error_get_last to a known state.  Note that it can never be
+        // reset; see http://php.net/manual/en/function.error-get-last.php
+        @trigger_error('control');
+        $error_description = error_get_last();
+        $this->assertEquals('control', $error_description['message']);
+        @trigger_error('');
+        $error_description = error_get_last();
+        $this->assertEquals('', $error_description['message']);
+
+        // Set error_reporting to a non-zero value.  In this instance,
+        // 'trigger_error' would abort our test script, so we use
+        // @trigger_error so that execution will continue.  With our
+        // error handler in place, the value of error_get_last() does
+        // not change.
         error_reporting(E_USER_ERROR);
         set_error_handler(array($this->runner, 'handleError'));
         @trigger_error('test error', E_USER_ERROR);
-        $this->assertEmpty(error_get_last());
+        $error_description = error_get_last();
+        $this->assertEquals('', $error_description['message']);
 
+        // Set error_reporting to zero.  Now, even 'trigger_error'
+        // does not abort execution.  The value of error_get_last()
+        // still does not change.
         error_reporting(0);
-        trigger_error('test error', E_USER_ERROR);
-        $this->assertEmpty(error_get_last());
+        trigger_error('test error 2', E_USER_ERROR);
+        $error_description = error_get_last();
+        $this->assertEquals('', $error_description['message']);
 
         error_reporting($tmpLevel);
     }


### PR DESCRIPTION
This test was failing for me locally; I am on php 5.6, but from reading the PHP docs, it seems this should have always been failing.  In any event, the version here works for me; let's see what Travis has to say.