### PR TITLE
Mark Result::_invoke() deprecated.

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -109,8 +109,12 @@ class Result implements \ArrayAccess
         return $this->exitCode === 0;
     }
 
+    /**
+     * @deprecated since 1.0.  @see wasSuccessful()
+     */
     public function __invoke()
     {
+        trigger_error(__METHOD__ . ' is deprecated: use wasSuccessful() instead.', E_USER_DEPRECATED);
         return $this->wasSuccessful();
     }
 


### PR DESCRIPTION
`$result()` is an odd pattern. Overriding `__invoke()` should be done in instances where the object in question is acting like a php `Callable` object.  Introducing this as a shortcut for an accessor is less desirable than simply using an accessor, as the intent of the code is not obvious.

Since there are better ways to detect errors and recover, we should mark this deprecated for 1.0, and remove it in 2.0.