### PR TITLE
Make stop on fail the default for FilesystemStack.  BREAKS backwards compatibility.

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -87,6 +87,8 @@ class Collection implements TaskInterface
      */
     public function rollback($rollbackTask)
     {
+        // Rollback tasks always try as hard as they can, and never report failures.
+        $rollbackTask = $this->ignoreErrorsTaskWrapper($rollbackTask);
         // Wrap the task as necessary.
         $rollbackTask = $this->wrapTask($rollbackTask);
         $collection = $this;
@@ -149,6 +151,12 @@ class Collection implements TaskInterface
      */
     public function ignoreErrorsTaskWrapper($task)
     {
+        // If the task is a stack-based task, then tell it
+        // to try to run all of its operations, even if some
+        // of them fail.
+        if ($task instanceof StackBasedTask) {
+            $task->stopOnFail(false);
+        }
         $task = $this->wrapTask($task);
         return function () use ($task) {
             $data = [];
@@ -328,6 +336,8 @@ class Collection implements TaskInterface
      */
     public function registerCompletion($completionTask)
     {
+        // Completion tasks always try as hard as they can, and never report failures.
+        $completionTask = $this->ignoreErrorsTaskWrapper($completionTask);
         // Wrap the task as necessary.
         $completionTask = $this->wrapTask($completionTask);
         if ($completionTask) {

--- a/src/Task/FileSystem/FilesystemStack.php
+++ b/src/Task/FileSystem/FilesystemStack.php
@@ -41,15 +41,9 @@ class FilesystemStack extends StackBasedTask
 {
     protected $fs;
 
-    /**
-     * Historically, FilesystemStack defaults to
-     * stopOnFail(false), but StackBasedTask defaults
-     * to stopOnFail(true).
-     */
     public function __construct()
     {
         $this->fs = new sfFileSystem();
-        $this->stopOnFail(false);
     }
 
     protected function getDelegate()


### PR DESCRIPTION
Also turns off stop on fail for any task that is added via addToCollectionAndIgnoreErrors().

This change is best for consistency, so that collections work correctly.  While this breaks backwards compatibility, any Robo script that relies on stopOnFail defaulting to false could use a little updating anyway.