### PR TITLE
Source and destination of the rsync command needs to be escaped

### DIFF
--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -286,8 +286,8 @@ class Rsync extends BaseTask implements CommandInterface
      */
     public function getCommand()
     {
-        $this->option(null, $this->getPathSpec('from'))
-            ->option(null, $this->getPathSpec('to'));
+        $this->option(null, escapeshellarg($this->getPathSpec('from')))
+            ->option(null, escapeshellarg($this->getPathSpec('to')));
 
         return $this->command . $this->arguments;
     }

--- a/tests/unit/Task/RsyncTest.php
+++ b/tests/unit/Task/RsyncTest.php
@@ -27,11 +27,31 @@ class RsyncTest extends \Codeception\TestCase\Test
                 ->humanReadable()
                 ->stats()
                 ->getCommand()
-        )->equals(sprintf('rsync --recursive --exclude %s --exclude %s --exclude %s --checksum --whole-file --verbose --progress --human-readable --stats src/ dev@localhost:/var/www/html/app/',
-            escapeshellarg('.git/'),
-            escapeshellarg('.svn/'),
-            escapeshellarg('.hg/')
-        ));
+        )->equals(
+            sprintf(
+                'rsync --recursive --exclude %s --exclude %s --exclude %s --checksum --whole-file --verbose --progress --human-readable --stats %s %s',
+                escapeshellarg('.git/'),
+                escapeshellarg('.svn/'),
+                escapeshellarg('.hg/'),
+                escapeshellarg('src/'),
+                escapeshellarg('dev@localhost:/var/www/html/app/')
+            )
+        );
+
+        verify(
+            $this->taskRsync()
+                ->fromPath('src/foo bar/baz')
+                ->toHost('localhost')
+                ->toUser('dev')
+                ->toPath('/var/path/with/a space')
+                ->getCommand()
+        )->equals(
+            sprintf(
+                'rsync %s %s',
+                escapeshellarg('src/foo bar/baz'),
+                escapeshellarg('dev@localhost:/var/path/with/a space')
+            )
+        );
     }
 
 }


### PR DESCRIPTION
The rsync fails if the source or destination path contains spaces.