### PR TITLE
Rename a file or directory, coping with cross-partition PHP bug

### DIFF
--- a/src/Task/Archive/Extract.php
+++ b/src/Task/Archive/Extract.php
@@ -89,16 +89,34 @@ class Extract extends BaseTask
             $filesInExtractLocation = glob("$extractLocation/*");
             $hasEncapsulatingFolder = ((count($filesInExtractLocation) == 1) && is_dir($filesInExtractLocation[0]));
             if ($hasEncapsulatingFolder && !$this->preserveTopDirectory) {
-                rename($filesInExtractLocation[0], $this->to);
+                $this->renameSafely($filesInExtractLocation[0], $this->to);
                 rmdir($extractLocation);
             } else {
-                rename($extractLocation, $this->to);
+                $this->renameSafely($extractLocation, $this->to);
             }
         }
         $this->stopTimer();
         $result['time'] = $this->getExecutionTime();
 
         return $result;
+    }
+
+    /**
+     * Rename a file or directory, coping with cross-partition PHP bug.
+     *
+     * @see https://bugs.php.net/bug.php?id=54097
+     *
+     * @param string $from
+     *   Location to rename from.
+     * @param string $to
+     *   Location to rename to.
+     */
+    protected function renameSafely($from, $to)
+    {
+        if (@rename($from, $to)) {
+            return;
+        }
+        exec("mv " . escapeshellarg($from) . " " . escapeshellarg($to));
     }
 
     protected function extractZip($extractLocation)


### PR DESCRIPTION
When extraction is done within e.g. `/var/www/...`, and then the result moved to `/tmp`, this can fail on a core PHP bug:

https://bugs.php.net/bug.php?id=54097

if `/var` and `/tmp` are on different filesystems.

The simple workaround on that bug report is implemented below; Drush has also historically implemented [a much more complex workaround](http://api.drush.org/api/drush/includes%21filesystem.inc/function/drush_move_dir/6.x).

See also drupal-composer/drupal-project#109 for initial discussion.