### PR TITLE
No premature exit

### DIFF
--- a/robo
+++ b/robo
@@ -16,4 +16,6 @@ if (strpos(basename(__FILE__), 'phar')) {
     }
 }
 $runner = new \Robo\Runner();
-$runner->execute();
+$exitCode = $runner->execute();
+exit($exitCode);
+

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -87,7 +87,8 @@ class Runner
             return;
         }
         $app->addCommandsFromClass($this->roboClass, $this->passThroughArgs);
-        $app->run($input);
+        $app->setAutoExit(false);
+        return $app->run($input);
     }
 
     /**

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -9,7 +9,7 @@ class Runner
 {
     use IO;
 
-    const VERSION = '0.7.0';
+    const VERSION = '0.7.1';
     const ROBOCLASS = 'RoboFile';
     const ROBOFILE = 'RoboFile.php';
 


### PR DESCRIPTION
Symfony by default calls 'exit', which is bad if you are calling Runner::execute() from some other application, and you'd like to do some extra work after the Runner is done.

This PR moves the call to `exit` to the main `robo` script, so that it is safe for others to call `Runner::execute()`.