### PR TITLE
Feature/task changelog with handler

### DIFF
--- a/docs/tasks/Development.md
+++ b/docs/tasks/Development.md
@@ -26,6 +26,24 @@ $this->taskChangelog()
 ?>
 ```
 
+Changes may be formatted into a custom file format. Handler can be either a function,
+a public method or a closure.
+
+``` php
+<?php
+$handler = function ($changelogTask)
+{
+    // how to manage contents of your CHANGELOG file
+}
+
+$this->taskChangelog()
+ ->handler($handler)
+ ->version($version)
+ ->askForChanges()
+ ->run();
+?>
+```
+
 * `Development\Changelog filename(string $filename)` 
 * `Development\Changelog anchor(string $anchor)` 
 * `Development\Changelog version(string $version)` 
@@ -34,6 +52,7 @@ $this->taskChangelog()
 * `changes(array $data)` 
 * `change($change)` 
 * `getChanges()` 
+* `handler($handler)`
 * `addToCollection($collection, $taskName = null, $rollbackTask = null)` 
 * `addAsRollback($collection)` 
 * `addAsCompletion($collection)` 

--- a/src/Task/Development/Changelog.php
+++ b/src/Task/Development/Changelog.php
@@ -31,6 +31,24 @@ use Robo\Task\Development;
  * ?>
  * ```
  *
+ * Changes may be formatted into a custom file format. Handler can be either a function,
+ * a public method or a closure.
+ *
+ * ``` php
+ * <?php
+ * function myChangelogHandler($changelogTask)
+ * {
+ *     // how to manage contents of your CHANGELOG file
+ * }
+ *
+ * $this->taskChangelog()
+ *  ->handler('myChangelogHandler')
+ *  ->version($version)
+ *  ->askForChanges()
+ *  ->run();
+ * ?>
+ * ```
+ *
  * @method Development\Changelog filename(string $filename)
  * @method Development\Changelog anchor(string $anchor)
  * @method Development\Changelog version(string $version)

--- a/src/Task/Development/Changelog.php
+++ b/src/Task/Development/Changelog.php
@@ -58,7 +58,7 @@ class Changelog extends BaseTask
     {
         while ($resp = $this->ask("Changed in this release: ")) {
             $this->log[] = $resp;
-        };
+        }
         return $this;
     }
 

--- a/src/Task/Development/Changelog.php
+++ b/src/Task/Development/Changelog.php
@@ -127,12 +127,14 @@ class Changelog extends BaseTask
     {
         return function () {
             $text = implode(
-                    "\n", array_map(
-                        function ($i) {
-                            return "* $i *" . date('Y-m-d') . "*";
-                        }, $this->log
-                    )
-                ) . "\n";
+                "\n",
+                array_map(
+                    function ($i) {
+                        return "* $i *" . date('Y-m-d') . "*";
+                    },
+                    $this->log
+                )
+            ) . "\n";
             $ver = "#### {$this->version}\n\n";
             $text = $ver . $text;
 

--- a/src/Task/Development/Changelog.php
+++ b/src/Task/Development/Changelog.php
@@ -3,7 +3,6 @@ namespace Robo\Task\Development;
 
 use Robo\Task\BaseTask;
 use Robo\Task\File\Replace;
-use Robo\Task\FileSystem;
 use Robo\Result;
 use Robo\Task\Development;
 

--- a/src/Task/Development/loadTasks.php
+++ b/src/Task/Development/loadTasks.php
@@ -9,7 +9,7 @@ trait loadTasks
      */
     protected function taskChangelog($filename = 'CHANGELOG.md')
     {
-        return new Changelog($filename);
+        return new Changelog($filename, $this);
     }
 
     /**
@@ -65,4 +65,4 @@ trait loadTasks
     {
         return new OpenBrowser($url);
     }
-} 
+}


### PR DESCRIPTION
Ability to customize our own changelog render with a callback.

Here is an example of new render:

```php
<?php
$closure = function ($changelogTask) {

    $anchor    = "# Change Log";
    $noversion = "## [Unreleased]";
    $filename  = $changelogTask->getFilename();
    $version   = $changelogTask->getVersion();
    
    $text = implode("\n", $changelogTask->getChanges());
    $ver  = "## \[{$version}\] - (\d+)-(\d+)-(\d+)\n\n";

    if (!file_exists($filename)) {
        //$changelogTask->printTaskInfo("Creating {$filename}");

        $contents  = $anchor;
        $contents .= "\n\n";
        $contents .= "All notable changes to this project will be documented in this file.\n";
        $contents .= "This project adheres to [Semantic Versioning](http://semver.org/),\n";
        $contents .= "using the [Keep a CHANGELOG](http://keepachangelog.com) principles.\n\n";
        $contents .= $noversion;
        $contents .= "\n\n";

        $res = file_put_contents($filename, $contents);
        if ($res === false) {
            return Result::error($changelogTask, "File {$filename} cant be created");
        }
    }

    // trying to append to changelog
    $result = (new Replace($filename))
        ->regex("~$ver~")
        ->to("\${0}$text\n")
        ->run();

    if (!$result->getData()['replaced']) {
        if (stripos('Unreleased', $version) === false) {
            $to = "## [{$version}] - " . date('Y-m-d') . "\n\n"
                . $text . "\n\n"
                . $noversion . "\n\n"
            ;
        } else {
            $to = $noversion . "\n\n" . $text . "\n";
        }

        $result = (new Replace($filename))
            ->from($noversion . "\n\n")
            ->to($to)
            ->run();
    }
    
};
                
$this->taskChangelog()
    ->handler($closure)
    ->version($version)
    ->askForChanges()
    ->run();                
```                

