### PR TITLE
make excludeVcs() recursive

### DIFF
--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -218,13 +218,17 @@ class Rsync extends BaseTask implements CommandInterface
     }
 
     /**
-     * Excludes .git/, .svn/ and .hg/ folders.
+     * Excludes .git, .svn and .hg items at any depth.
      *
      * @return $this
      */
     public function excludeVcs()
     {
-        return $this->exclude(['.git/', '.svn/', '.hg/']);
+        return $this->exclude([
+            '.git',
+            '.svn',
+            '.hg',
+        ]);
     }
 
     public function exclude($pattern)

--- a/tests/unit/Task/RsyncTest.php
+++ b/tests/unit/Task/RsyncTest.php
@@ -30,9 +30,9 @@ class RsyncTest extends \Codeception\TestCase\Test
         )->equals(
             sprintf(
                 'rsync --recursive --exclude %s --exclude %s --exclude %s --checksum --whole-file --verbose --progress --human-readable --stats %s %s',
-                escapeshellarg('.git/'),
-                escapeshellarg('.svn/'),
-                escapeshellarg('.hg/'),
+                escapeshellarg('.git'),
+                escapeshellarg('.svn'),
+                escapeshellarg('.hg'),
                 escapeshellarg('src/'),
                 escapeshellarg('dev@localhost:/var/www/html/app/')
             )


### PR DESCRIPTION
I just noticed that the excludeVcs() did not exclude git submodules.
So I added an option for git, svn, hg each.