### PR TITLE
Standalone Robo scripts.

### DIFF
--- a/script.robo
+++ b/script.robo
@@ -1,0 +1,35 @@
+#!/usr/bin/env robo
+<?php
+
+/**
+ * Standalone Robo script.
+ *
+ * This file may be executed from the shell as if it were a
+ * bash script.
+ *
+ * Example:
+ *
+ * $ ./script.robo foo bar
+ * ➜  This is a standalone Robo script, bar
+ *
+ * Note that in order for this to work, the 'robo' script
+ * must be in your $PATH.  Usually, this is done by installing
+ * Robo via 'composer global require', and placing ~/.composer/vendor/bin
+ * on your $PATH.  Then, any Robo libraries that are also installed
+ * via 'composer global require' will be available for use in all
+ * Robo standalone scripts.
+ */
+class MyRoboScript extends \Robo\Tasks
+{
+    /**
+     * Foo
+     *
+     * A demonstration of a command in a standalone Robo script.
+     *
+     * @param string $name a name that is printed.
+     */
+    public function foo($name)
+    {
+        $this->say("This is a standalone Robo script, $name");
+    }
+}

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -181,7 +181,7 @@ class Runner
         }
 
         // loading from other directory
-        $pos = array_search('--load-from', $argv);
+        $pos = array_search('--load-from', $argv) ?: array_search('-f', $argv);
         if ($pos !== false) {
             if (isset($argv[$pos +1])) {
                 $this->dir = $argv[$pos +1];

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -108,7 +108,7 @@ class Runner
         // The robo class may contain multiple commands; the user may
         // select which one to run, or even get a list of commands or
         // run 'help' on any of the available commands as usual.
-        if ($this->isShebangFile($args[1])) {
+        if ((count($args) > 1) && $this->isShebangFile($args[1])) {
             return array_merge([$args[0]], array_slice($args, 2));
         }
         // Option 2: Shebang line stipulates which command to run.
@@ -116,7 +116,7 @@ class Runner
         // The robo class must contain a public method named 'mycommand'.
         // This command will be executed every time.  Arguments and options
         // may be provided on the commandline as usual.
-        if ($this->isShebangFile($args[2])) {
+        if ((count($args) > 2) && $this->isShebangFile($args[2])) {
             return array_merge([$args[0]], explode(' ', $args[1]), array_slice($args, 3));
         }
         return $args;

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -192,6 +192,10 @@ class Runner
             if (is_file($this->dir)) {
                 $this->roboFile = basename($this->dir);
                 $this->dir = dirname($this->dir);
+                $className = basename($this->roboFile, '.php');
+                if ($className != $this->roboFile) {
+                    $this->roboClass = $className;
+                }
             }
         }
         return new ArgvInput($argv);

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -163,7 +163,7 @@ class Runner
      */
     protected function isShebangLine($line)
     {
-        return ((substr($line,0,2) == '#!') && (strstr($line, 'robo') !== FALSE));
+        return ((substr($line, 0, 2) == '#!') && (strstr($line, 'robo') !== false));
     }
 
     /**


### PR DESCRIPTION
This PR allows the user to write standalone Robo scripts that can be executed like other shell scripts. Both multi-command (./myscript mycommand arg) and single-command (./myscript arg) variants are supported.

Requires that `robo` be in your `$PATH`.