### PR TITLE
Changed increment method to following semantic versioning specification

### DIFF
--- a/src/Task/Development/SemVer.php
+++ b/src/Task/Development/SemVer.php
@@ -84,16 +84,25 @@ class SemVer implements TaskInterface
 
     public function increment($what = 'patch')
     {
-        $types = ['major', 'minor', 'patch'];
-        if (!in_array($what, $types)) {
-            throw new TaskException(
-                $this,
-                'Bad argument, only one of the following is allowed: ' .
-                implode(', ', $types)
-            );
+        switch ($what) {
+            case 'major':
+                $this->version['major']++;
+                $this->version['minor'] = 0;
+                $this->version['patch'] = 0;
+                break;
+            case 'minor':
+                $this->version['minor']++;
+                $this->version['patch'] = 0;
+                break;
+            case 'patch':
+                $this->version['patch']++;
+                break;
+            default:
+                throw new TaskException(
+                    $this,
+                    'Bad argument, only one of the following is allowed: major, minor, patch'
+                );
         }
-
-        $this->version[$what]++;
         return $this;
     }
 

--- a/tests/unit/Task/SemVerTest.php
+++ b/tests/unit/Task/SemVerTest.php
@@ -18,6 +18,48 @@ class SemVerTest extends \Codeception\TestCase\Test
         $semver->verifyInvoked('dump');
     }
 
+    public function testSemverIncrementMinorAfterIncrementedPatch()
+    {
+        $semver = test::double('Robo\Task\Development\SemVer', ['dump' => null]);
+        $res = $this->taskSemVer()
+            ->increment('patch')
+            ->run();
+        verify($res->getMessage())->equals('v0.0.1');
+        $res = $this->taskSemVer()
+            ->increment('minor')
+            ->run();
+        verify($res->getMessage())->equals('v0.1.0');
+        $semver->verifyInvoked('dump');
+    }
+
+    public function testSemverIncrementMajorAfterIncrementedMinorAndPatch()
+    {
+        $semver = test::double('Robo\Task\Development\SemVer', ['dump' => null]);
+        $res = $this->taskSemVer()
+            ->increment('patch')
+            ->run();
+        verify($res->getMessage())->equals('v0.0.1');
+        $res = $this->taskSemVer()
+            ->increment('minor')
+            ->run();
+        verify($res->getMessage())->equals('v0.1.0');
+        $res = $this->taskSemVer()
+            ->increment('major')
+            ->run();
+        verify($res->getMessage())->equals('v1.0.0');
+        $semver->verifyInvoked('dump');
+    }
+
+    public function testThrowsExceptionWhenIncrementWithWrongParameter()
+    {
+        \PHPUnit_Framework_TestCase::setExpectedExceptionRegExp(
+            'Robo\Exception\TaskException',
+            '/Bad argument, only one of the following is allowed: major, minor, patch/'
+        );
+        $this->taskSemVer()
+            ->increment('wrongParameter');
+    }
+
     public function testThrowsExceptionWhenSemverFileNotWriteable()
     {
         \PHPUnit_Framework_TestCase::setExpectedExceptionRegExp(


### PR DESCRIPTION
I think the existing implementation of increment does not follow the semantic versioning specification:

- Increment of major must reset minor and patch to 0.
- Increment of minor must reset patch to 0.

Have a look at:
http://semver.org/#spec-item-7
http://semver.org/#spec-item-8
