### PR TITLE
Restore rsync test backed out in previous merge.

### DIFF
--- a/tests/unit/Task/RsyncTest.php
+++ b/tests/unit/Task/RsyncTest.php
@@ -36,10 +36,30 @@ class RsyncTest extends \Codeception\TestCase\Test
                 ->humanReadable()
                 ->stats()
                 ->getCommand()
-        )->equals(sprintf('rsync --recursive --exclude %s --exclude %s --exclude %s --checksum --whole-file --verbose --progress --human-readable --stats src/ dev@localhost:/var/www/html/app/',
-            escapeshellarg('.git'),
-            escapeshellarg('.svn'),
-            escapeshellarg('.hg')
-        ));
+        )->equals(
+            sprintf(
+                'rsync --recursive --exclude %s --exclude %s --exclude %s --checksum --whole-file --verbose --progress --human-readable --stats %s %s',
+                escapeshellarg('.git'),
+                escapeshellarg('.svn'),
+                escapeshellarg('.hg'),
+                escapeshellarg('src/'),
+                escapeshellarg('dev@localhost:/var/www/html/app/')
+            )
+        );
+
+        verify(
+            $this->container->get('taskRsync')
+                ->fromPath('src/foo bar/baz')
+                ->toHost('localhost')
+                ->toUser('dev')
+                ->toPath('/var/path/with/a space')
+                ->getCommand()
+        )->equals(
+            sprintf(
+                'rsync %s %s',
+                escapeshellarg('src/foo bar/baz'),
+                escapeshellarg('dev@localhost:/var/path/with/a space')
+            )
+        );
     }
 }


### PR DESCRIPTION
This PR restores an rsync test that I backed out when merging the DI and PSR-logger stuff.  It looks like an attempt to handle spaces in filenames (e.g. for Windows), so perhaps there was some rsync commit that was also lost somewhere along the way. This bears some investigation.