### PR TITLE
Added optional parameter message to git tag

### DIFF
--- a/src/Task/Vcs/GitStack.php
+++ b/src/Task/Vcs/GitStack.php
@@ -119,13 +119,17 @@ class GitStack extends CommandStack
      * Executes `git tag` command
      *
      * @param $tag_name
+     * @param string $message
      * @return $this
      */
-    public function tag($tag_name)
+    public function tag($tag_name, $message = "")
     {
-        return $this->exec([__FUNCTION__, $tag_name]);
+        if ($message != "") {
+            $message = "-m '$message'";
+        }
+        return $this->exec([__FUNCTION__, $message, $tag_name]);
     }
-    
+
     public function run()
     {
         $this->printTaskInfo("Running git commands...");

--- a/tests/unit/Task/GitTest.php
+++ b/tests/unit/Task/GitTest.php
@@ -5,6 +5,7 @@ use Robo\Config;
 
 class GitTest extends \Codeception\TestCase\Test
 {
+
     protected $container;
 
     /**
@@ -21,6 +22,7 @@ class GitTest extends \Codeception\TestCase\Test
         $this->container = Config::getContainer();
         $this->container->addServiceProvider(\Robo\Task\Vcs\loadTasks::getVcsServices());
     }
+
     // tests
     public function testGitStackRun()
     {
@@ -42,8 +44,24 @@ class GitTest extends \Codeception\TestCase\Test
                 ->commit('changed')
                 ->push()
                 ->tag('0.6.0')
-                ->push('origin','0.6.0')
+                ->push('origin', '0.6.0')
                 ->getCommand()
         )->equals("git clone http://github.com/Codegyre/Robo && git pull && git add -A && git commit -m 'changed' && git push && git tag 0.6.0 && git push origin 0.6.0");
     }
+
+    public function testGitStackCommandsWithTagMessage()
+    {
+        verify(
+            $this->container->get('taskGitStack')
+                ->cloneRepo('http://github.com/Codegyre/Robo')
+                ->pull()
+                ->add('-A')
+                ->commit('changed')
+                ->push()
+                ->tag('0.6.0', 'message')
+                ->push('origin', '0.6.0')
+                ->getCommand()
+        )->equals("git clone http://github.com/Codegyre/Robo && git pull && git add -A && git commit -m 'changed' && git push && git tag -m 'message' 0.6.0 && git push origin 0.6.0");
+    }
+
 }


### PR DESCRIPTION
I added an optional parameter message to the method tag from GitStack. 

Now I can tag with a message like this:
`$this->taskGitStack()->tag($semVer, $message)->run();`

Previously I needed to do it manually with Exec:
`$this->taskExec('git tag -m "' . $message . '" ' . $semVer)->run();`