### PR TITLE
Task 'ask' convenience functions must now be given $io

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -87,7 +87,7 @@ class RoboFile extends \Robo\Tasks
 
         $this->taskGitHubRelease(\Robo\Runner::VERSION)
             ->uri('Codegyre/Robo')
-            ->askDescription()
+            ->askDescription($this)
             ->run();
 
         $this->versionBump();

--- a/src/Task/Development/Changelog.php
+++ b/src/Task/Development/Changelog.php
@@ -27,7 +27,7 @@ use Robo\Task\Development;
  * <?php
  * $this->taskChangelog()
  *  ->version($version)
- *  ->askForChanges()
+ *  ->askForChanges($this)
  *  ->run();
  * ?>
  * ```
@@ -56,9 +56,9 @@ class Changelog extends BaseTask
         return \Robo\Config::getContainer()->get('taskChangelog', [$filename]);
     }
 
-    public function askForChanges()
+    public function askForChanges($io)
     {
-        while ($resp = $this->ask("Changed in this release: ")) {
+        while ($resp = $io->ask("Changed in this release: ")) {
             $this->log[] = $resp;
         };
         return $this;

--- a/src/Task/Development/GitHub.php
+++ b/src/Task/Development/GitHub.php
@@ -32,14 +32,14 @@ abstract class GitHub extends BaseTask
         return $this->owner . '/' . $this->repo;
     }
 
-    public function askAuth()
+    public function askAuth($io)
     {
-        self::$user = $this->ask('GitHub User');
-        self::$pass = $this->askHidden('Password');
+        self::$user = $io->ask('GitHub User');
+        self::$pass = $io->askHidden('Password');
         return $this;
     }
 
-    protected function sendRequest($uri, $params = [], $method = 'POST')
+    protected function sendRequest($uri, $params = [], $method = 'POST', $io = false)
     {
         if (!$this->owner or !$this->repo) {
             throw new TaskException($this, 'Repo URI is not set');
@@ -49,8 +49,8 @@ abstract class GitHub extends BaseTask
         $url = sprintf('%s/repos/%s/%s', self::GITHUB_URL, $this->getUri(), $uri);
         $this->printTaskInfo('{method} {$url}', ['method' => $method, 'url' => $url]);
 
-        if (!self::$user) {
-            $this->askAuth();
+        if (!self::$user && $io) {
+            $this->askAuth($io);
             curl_setopt($ch, CURLOPT_USERPWD, self::$user . ':' . self::$pass);
         }
 

--- a/src/Task/Development/GitHubRelease.php
+++ b/src/Task/Development/GitHubRelease.php
@@ -11,7 +11,7 @@ use Robo\Result;
  * <?php
  * $this->taskGitHubRelease('0.1.0')
  *   ->uri('Codegyre/Robo')
- *   ->askDescription()
+ *   ->askDescription($this)
  *   ->run();
  * ?>
  * ```
@@ -39,22 +39,22 @@ class GitHubRelease extends GitHub
         $this->tag = $tag;
     }
 
-    public function askName()
+    public function askName($io)
     {
-        $this->name = $this->ask("Release Title");
+        $this->name = $io->ask("Release Title");
         return $this;
     }
 
-    public function askDescription()
+    public function askDescription($io)
     {
-        $this->body .= $this->ask("Description of Release\n") . "\n\n";
+        $this->body .= $io->ask("Description of Release\n") . "\n\n";
         return $this;
     }
 
-    public function askForChanges()
+    public function askForChanges($io)
     {
         $this->body .= "### Changelog \n\n";
-        while ($resp = $this->ask("Added in this release:")) {
+        while ($resp = $io->ask("Added in this release:")) {
             $this->body .= "* $resp\n";
         };
         return $this;


### PR DESCRIPTION
Pursuant to #295, Tasks that include a convenience function that calls 'ask' must now be provided an IO object. $this will usually suffice.