### PR TITLE
Avoid use of DynamicParams trait in Robo core.

### DIFF
--- a/src/Task/Archive/Extract.php
+++ b/src/Task/Archive/Extract.php
@@ -32,7 +32,6 @@ use Robo\Task\BaseTask;
  */
 class Extract extends BaseTask
 {
-    use \Robo\Common\DynamicParams;
     use \Robo\Common\Timer;
 
     protected $filename;
@@ -42,6 +41,18 @@ class Extract extends BaseTask
     public function __construct($filename)
     {
         $this->filename = $filename;
+    }
+
+    public function to($to)
+    {
+        $this->to = $to;
+        return $this;
+    }
+
+    public function preserveTopDirectory($preserve = true)
+    {
+        $this->preserveTopDirectory = $preserve;
+        return $this;
     }
 
     public function run()

--- a/src/Task/Archive/Pack.php
+++ b/src/Task/Archive/Pack.php
@@ -23,7 +23,6 @@ use Symfony\Component\Finder\Finder;
  */
 class Pack extends BaseTask implements PrintedInterface
 {
-    use \Robo\Common\DynamicParams;
     use \Robo\Common\Timer;
 
     /**
@@ -63,6 +62,12 @@ class Pack extends BaseTask implements PrintedInterface
     public function getPrinted()
     {
         return true;
+    }
+
+    public function archiveFile($archiveFile)
+    {
+        $this->archiveFile = $archiveFile;
+        return $this;
     }
 
     /**

--- a/src/Task/Base/ParallelExec.php
+++ b/src/Task/Base/ParallelExec.php
@@ -31,7 +31,6 @@ use Symfony\Component\Process\Process;
 class ParallelExec extends BaseTask implements CommandInterface, PrintedInterface
 {
     use Timer;
-    use \Robo\Common\DynamicParams;
     use \Robo\Common\CommandReceiver;
     use \Robo\Common\IO;
 
@@ -54,6 +53,18 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
     public function process($command)
     {
         $this->processes[] = new Process($this->receiveCommand($command));
+        return $this;
+    }
+
+    public function timeout($timeout)
+    {
+        $this->timeout = $timeout;
+        return $this;
+    }
+
+    public function idleTimeout($idleTimeout)
+    {
+        $this->idleTimeout = $idleTimeout;
         return $this;
     }
 

--- a/src/Task/CommandStack.php
+++ b/src/Task/CommandStack.php
@@ -11,7 +11,6 @@ use Robo\Exception\TaskException;
 
 abstract class CommandStack extends BaseTask implements CommandInterface, PrintedInterface
 {
-    use DynamicParams;
     use ExecCommand;
 
     protected $executable;
@@ -24,6 +23,12 @@ abstract class CommandStack extends BaseTask implements CommandInterface, Printe
         return implode(' && ', $this->exec);
     }
 
+    public function executable($executable)
+    {
+        $this->executable = $executable;
+        return $this;
+    }
+
     public function exec($command)
     {
         if (is_array($command)) {
@@ -32,6 +37,18 @@ abstract class CommandStack extends BaseTask implements CommandInterface, Printe
 
         $command = $this->executable . ' ' . $this->stripExecutableFromCommand($command);
         array_push($this->exec, trim($command));
+        return $this;
+    }
+
+    public function stopOnFail($stopOnFail = true)
+    {
+        $this->stopOnFail = $stopOnFail;
+        return $this;
+    }
+
+    public function result($result)
+    {
+        $this->result = $result;
         return $this;
     }
 

--- a/src/Task/Development/Changelog.php
+++ b/src/Task/Development/Changelog.php
@@ -38,8 +38,6 @@ use Robo\Task\Development;
  */
 class Changelog extends BaseTask
 {
-    use \Robo\Common\DynamicParams;
-
     protected $filename;
     protected $log = [];
     protected $anchor = "# Changelog";
@@ -54,6 +52,30 @@ class Changelog extends BaseTask
     public static function init($filename = 'CHANGELOG.md')
     {
         return \Robo\Config::getContainer()->get('taskChangelog', [$filename]);
+    }
+
+    public function filename($filename)
+    {
+        $this->filename = $filename;
+        return $this;
+    }
+
+    public function log($item)
+    {
+        $this->log[] = $item;
+        return $this;
+    }
+
+    public function anchor($anchor)
+    {
+        $this->anchor = $anchor;
+        return $this;
+    }
+
+    public function version($version)
+    {
+        $this->version = $version;
+        return $this;
     }
 
     public function askForChanges()

--- a/src/Task/Development/GenerateMarkdownDoc.php
+++ b/src/Task/Development/GenerateMarkdownDoc.php
@@ -60,8 +60,6 @@ use Robo\Task\Development;
  */
 class GenerateMarkdownDoc extends BaseTask
 {
-    use \Robo\Common\DynamicParams;
-
     protected $docClass = [];
     protected $filterMethods;
     protected $filterClasses;
@@ -105,6 +103,132 @@ class GenerateMarkdownDoc extends BaseTask
     public function __construct($filename)
     {
         $this->filename = $filename;
+    }
+
+    public function docClass($item)
+    {
+        $this->docClass[] = $item;
+        return $this;
+    }
+
+    public function filterMethods($filterMethods)
+    {
+        $this->filterMethods = $filterMethods;
+        return $this;
+    }
+
+    public function filterClasses($filterClasses)
+    {
+        $this->filterClasses = $filterClasses;
+        return $this;
+    }
+
+    public function filterProperties($filterProperties)
+    {
+        $this->filterProperties = $filterProperties;
+        return $this;
+    }
+
+    public function processClass($processClass)
+    {
+        $this->processClass = $processClass;
+        return $this;
+    }
+
+    public function processClassSignature($processClassSignature)
+    {
+        $this->processClassSignature = $processClassSignature;
+        return $this;
+    }
+
+    public function processClassDocBlock($processClassDocBlock)
+    {
+        $this->processClassDocBlock = $processClassDocBlock;
+        return $this;
+    }
+
+    public function processMethod($processMethod)
+    {
+        $this->processMethod = $processMethod;
+        return $this;
+    }
+
+    public function processMethodSignature($processMethodSignature)
+    {
+        $this->processMethodSignature = $processMethodSignature;
+        return $this;
+    }
+
+    public function processMethodDocBlock($processMethodDocBlock)
+    {
+        $this->processMethodDocBlock = $processMethodDocBlock;
+        return $this;
+    }
+
+    public function processProperty($processProperty)
+    {
+        $this->processProperty = $processProperty;
+        return $this;
+    }
+
+    public function processPropertySignature($processPropertySignature)
+    {
+        $this->processPropertySignature = $processPropertySignature;
+        return $this;
+    }
+
+    public function processPropertyDocBlock($processPropertyDocBlock)
+    {
+        $this->processPropertyDocBlock = $processPropertyDocBlock;
+        return $this;
+    }
+
+    public function reorder($reorder)
+    {
+        $this->reorder = $reorder;
+        return $this;
+    }
+
+    public function reorderMethods($reorderMethods)
+    {
+        $this->reorderMethods = $reorderMethods;
+        return $this;
+    }
+
+    public function reorderProperties($reorderProperties)
+    {
+        $this->reorderProperties = $reorderProperties;
+        return $this;
+    }
+
+    public function filename($filename)
+    {
+        $this->filename = $filename;
+        return $this;
+    }
+
+    public function prepend($prepend)
+    {
+        $this->prepend = $prepend;
+        return $this;
+    }
+
+    public function append($append)
+    {
+        $this->append = $append;
+        return $this;
+    }
+
+    public function text($text)
+    {
+        $this->text = $text;
+        return $this;
+    }
+
+    public function textForClass($item)
+    {
+        $this->textForClass[] = $item;
+        return $this;
     }
 
     public function run()

--- a/src/Task/Development/GitHub.php
+++ b/src/Task/Development/GitHub.php
@@ -10,8 +10,6 @@ use Robo\Task\BaseTask;
  */
 abstract class GitHub extends BaseTask
 {
-    use \Robo\Common\DynamicParams;
-
     const GITHUB_URL = 'https://api.github.com';
 
     protected static $user;
@@ -20,6 +18,23 @@ abstract class GitHub extends BaseTask
     protected $needs_auth = false;
     protected $repo;
     protected $owner;
+
+    public function needs_auth($needs_auth)
+    {
+        $this->needs_auth = $needs_auth;
+        return $this;
+    }
+
+    public function repo($repo)
+    {
+        $this->repo = $repo;
+        return $this;
+    }
+
+    public function owner($owner)
+    {
+        $this->owner = $owner;
+    }
 
     public function uri($uri)
     {

--- a/src/Task/Development/GitHub.php
+++ b/src/Task/Development/GitHub.php
@@ -15,15 +15,8 @@ abstract class GitHub extends BaseTask
     protected static $user;
     protected static $pass;
 
-    protected $needs_auth = false;
     protected $repo;
     protected $owner;
-
-    public function needs_auth($needs_auth)
-    {
-        $this->needs_auth = $needs_auth;
-        return $this;
-    }
 
     public function repo($repo)
     {

--- a/src/Task/File/Replace.php
+++ b/src/Task/File/Replace.php
@@ -37,8 +37,6 @@ use Robo\Task\BaseTask;
  */
 class Replace extends BaseTask
 {
-    use \Robo\Common\DynamicParams;
-
     protected $filename;
     protected $from;
     protected $to;
@@ -47,6 +45,30 @@ class Replace extends BaseTask
     public function __construct($filename)
     {
         $this->filename = $filename;
+    }
+
+    public function filename($filename)
+    {
+        $this->filename = $filename;
+        return $this;
+    }
+
+    public function from($from)
+    {
+        $this->from = $from;
+        return $this;
+    }
+
+    public function to($to)
+    {
+        $this->to = $to;
+        return $this;
+    }
+
+    public function regex($regex)
+    {
+        $this->regex = $regex;
+        return $this;
     }
 
     public function run()

--- a/src/Task/File/Write.php
+++ b/src/Task/File/Write.php
@@ -22,14 +22,24 @@ use Robo\Task\BaseTask;
  */
 class Write extends BaseTask
 {
-    use \Robo\Common\DynamicParams;
-
     protected $filename;
     protected $append = false;
 
     public function __construct($filename)
     {
         $this->filename = $filename;
+    }
+
+    public function filename($filename)
+    {
+        $this->filename = $filename;
+        return $this;
+    }
+
+    public function append($append = true)
+    {
+        $this->append = $append;
+        return $this;
     }
 
     /**

--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -53,7 +53,6 @@ use Robo\Exception\TaskException;
 class Rsync extends BaseTask implements CommandInterface
 {
     use \Robo\Common\ExecOneCommand;
-    use \Robo\Common\DynamicParams;
 
     protected $command;
 
@@ -104,6 +103,30 @@ class Rsync extends BaseTask implements CommandInterface
     {
         $this->toPath = $path;
 
+        return $this;
+    }
+
+    public function fromUser($fromUser)
+    {
+        $this->fromUser = $fromUser;
+        return $this;
+    }
+
+    public function fromHost($fromHost)
+    {
+        $this->fromHost = $fromHost;
+        return $this;
+    }
+
+    public function toUser($toUser)
+    {
+        $this->toUser = $toUser;
+        return $this;
+    }
+
+    public function toHost($toHost)
+    {
+        $this->toHost = $toHost;
         return $this;
     }
 

--- a/src/Task/Remote/Ssh.php
+++ b/src/Task/Remote/Ssh.php
@@ -47,7 +47,6 @@ use Robo\Task\BaseTask;
  */
 class Ssh extends BaseTask implements CommandInterface
 {
-    use \Robo\Common\DynamicParams;
     use \Robo\Common\CommandReceiver;
     use \Robo\Common\ExecOneCommand;
 
@@ -70,6 +69,30 @@ class Ssh extends BaseTask implements CommandInterface
     {
         $this->hostname = $hostname;
         $this->user = $user;
+    }
+
+    public function hostname($hostname)
+    {
+        $this->hostname = $hostname;
+        return $this;
+    }
+
+    public function user($user)
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    public function stopOnFail($stopOnFail = true)
+    {
+        $this->stopOnFail = $stopOnFail;
+        return $this;
+    }
+
+    public function remoteDir($remoteDir)
+    {
+        $this->remoteDir = $remoteDir;
+        return $this;
     }
 
     public function identityFile($filename)

--- a/tests/unit/Task/CommandStackTest.php
+++ b/tests/unit/Task/CommandStackTest.php
@@ -13,10 +13,9 @@ class CommandStackTest extends \Codeception\TestCase\Test
 
     public function testExecStackExecutableIsTrimmedFromCommand()
     {
-        $commandStack = Stub::make('Robo\Task\CommandStack', array(
-            'executable' => 'some-executable'
-        ));
+        $commandStack = Stub::make('Robo\Task\CommandStack');
         verify($commandStack
+                ->executable('some-executable')
                 ->exec('some-executable status')
                 ->getCommand()
         )->equals('some-executable status');
@@ -24,10 +23,9 @@ class CommandStackTest extends \Codeception\TestCase\Test
 
     public function testExecStackCommandIsNotTrimmedIfHavingSameCharsAsExecutable()
     {
-        $commandStack = Stub::make('Robo\Task\CommandStack', array(
-            'executable' => 'some-executable'
-        ));
+        $commandStack = Stub::make('Robo\Task\CommandStack');
         verify($commandStack
+                ->executable('some-executable')
                 ->exec('status')
                 ->getCommand()
         )->equals('some-executable status');


### PR DESCRIPTION
The existence of a magic `__call()` function in a class makes it harder for code analyzers, as they cannot tell if a call to a missing function is or is not handled by the magic function.

DynamicParams makes it a bit faster to write new tasks, and should be maintained for the convenience of external task writers. It's only a little extra code to add to Robo core, though, and having explicit functions will be better overall.

See #295.