### PR TITLE
Move 'task' shortcut to a new TaskAccessor trait.

### DIFF
--- a/src/Task/Archive/Extract.php
+++ b/src/Task/Archive/Extract.php
@@ -94,10 +94,10 @@ class Extract extends BaseTask
                 rename($extractLocation, $this->to);
             }
             if ($hasEncapsulatingFolder && !$this->preserveTopDirectory) {
-                $result = $this->getContainer()->get('taskFilesystemStack')->rename($filesInExtractLocation[0], $this->to)->run();
+                $result = $this->task('FilesystemStack')->rename($filesInExtractLocation[0], $this->to)->run();
                 @rmdir($extractLocation);
             } else {
-                $result = $this->getContainer()->get('taskFilesystemStack')->rename($extractLocation, $this->to)->run();
+                $result = $this->task('FilesystemStack')->rename($extractLocation, $this->to)->run();
             }
         }
         $this->stopTimer();

--- a/src/Task/BaseTask.php
+++ b/src/Task/BaseTask.php
@@ -3,6 +3,7 @@ namespace Robo\Task;
 
 use Robo\Common\Configuration;
 use Robo\Common\TaskIO;
+use Robo\TaskAccessor;
 use Robo\Collection\Collectable;
 use Robo\Contract\TaskInterface;
 use Psr\Log\LoggerAwareInterface;
@@ -13,6 +14,8 @@ use League\Container\ContainerAwareTrait;
 abstract class BaseTask implements TaskInterface, LoggerAwareInterface, ContainerAwareInterface
 {
     use TaskIO; // uses LoggerAwareTrait
+    use TaskAccessor;
+
     use ContainerAwareTrait;
     use Configuration;
     use Collectable;

--- a/src/Task/Development/Changelog.php
+++ b/src/Task/Development/Changelog.php
@@ -112,13 +112,13 @@ class Changelog extends BaseTask
         }
 
         // trying to append to changelog for today
-        $result = $this->getContainer()->get('taskReplaceInFile', [$this->filename])
+        $result = $this->task('ReplaceInFile', $this->filename)
             ->from($ver)
             ->to($text)
             ->run();
 
         if (!$result->getData()['replaced']) {
-            $result = $this->getContainer()->get('taskReplaceInFile', [$this->filename])
+            $result = $this->task('ReplaceInFile', $this->filename)
                 ->from($this->anchor)
                 ->to($this->anchor . "\n\n" . $text)
                 ->run();

--- a/src/Task/Development/GenerateMarkdownDoc.php
+++ b/src/Task/Development/GenerateMarkdownDoc.php
@@ -121,7 +121,7 @@ class GenerateMarkdownDoc extends BaseTask
 
         $this->text = implode("\n", $this->textForClass);
 
-        $result = $this->getContainer()->get('taskWriteToFile', [$this->filename])
+        $result = $this->task('WriteToFile', $this->filename)
             ->line($this->prepend)
             ->text($this->text)
             ->line($this->append)

--- a/src/Task/FileSystem/FilesystemStack.php
+++ b/src/Task/FileSystem/FilesystemStack.php
@@ -88,12 +88,12 @@ class FilesystemStack extends StackBasedTask
             // adequately rollback.  Perhaps we need to preflight the operation
             // and determine if everything inside of $target is writable.
             if (file_exists($target)) {
-                $deleteResult = $this->getContainer()->get('taskDeleteDir', [$target])->run();
+                $deleteResult = $this->task('taskDeleteDir', $target)->run();
                 if (!$deleteResult->wasSuccessful()) {
                     return $deleteResult;
                 }
             }
-            $result = $this->getContainer()->get('taskCopyDir', [[$origin => $target]])->run();
+            $result = $this->task('taskCopyDir', [$origin => $target])->run();
             if (!$result->wasSuccessful()) {
                 return $result;
             }

--- a/src/Task/FileSystem/TmpDir.php
+++ b/src/Task/FileSystem/TmpDir.php
@@ -99,7 +99,7 @@ class TmpDir extends BaseDir implements CompletionInterface
         if ($this->cwd) {
             chdir($this->savedWorkingDirectory);
         }
-        $this->getContainer()->get('taskDeleteDir', [$this->dirs])->run();
+        $this->task('taskDeleteDir', $this->dirs)->run();
     }
 
     /**

--- a/src/TaskAccessor.php
+++ b/src/TaskAccessor.php
@@ -1,0 +1,40 @@
+<?php
+namespace Robo;
+
+trait TaskAccessor
+{
+    /**
+     * Commands that use TaskAccessor must provide 'getContainer()'.
+     */
+    abstract function getContainer();
+
+    /**
+     * Convenience function. Use:
+     *
+     * $this->task('Foo', $a, $b);
+     *
+     * instead of:
+     *
+     * $this->getContainer()->get('taskFoo', [$a, $b]);
+     *
+     * Note that most tasks will define another convenience
+     * function, $this->taskFoo($a, $b), declared in a
+     * 'loadTasks' trait in the task's namespace.  These
+     * 'loadTasks' convenience functions typically will call
+     * $this->task() to ensure that task objects are fetched
+     * from the container, so that their dependencies may be
+     * automatically resolved.
+     */
+    protected function task()
+    {
+        $args = func_get_args();
+        $name = array_shift($args);
+        // We'll allow callers to include the literal 'task'
+        // or not, as they wish; however, the container object
+        // that we fetch must always begin with 'task'
+        if (!preg_match('#^task#', $name)) {
+            $name = "task$name";
+        }
+        return $this->getContainer()->get($name, $args);
+    }
+}

--- a/src/TaskAccessor.php
+++ b/src/TaskAccessor.php
@@ -6,7 +6,7 @@ trait TaskAccessor
     /**
      * Commands that use TaskAccessor must provide 'getContainer()'.
      */
-    abstract function getContainer();
+    public abstract function getContainer();
 
     /**
      * Convenience function. Use:

--- a/src/Tasklib.php
+++ b/src/Tasklib.php
@@ -3,6 +3,8 @@ namespace Robo;
 
 trait Tasklib
 {
+    use TaskAccessor;
+
     // standard tasks
     use Task\Base\loadTasks;
     use Task\Development\loadTasks;
@@ -34,11 +36,6 @@ trait Tasklib
     use Task\Vcs\loadShortcuts;
 
     /**
-     * Commands that use TaskLib must provide 'getContainer()'.
-     */
-    abstract function getContainer();
-
-    /**
      * Convenience function. Use:
      *
      * $this->collection();
@@ -50,35 +47,5 @@ trait Tasklib
     protected function collection()
     {
         return $this->getContainer()->get('collection');
-    }
-
-    /**
-     * Convenience function. Use:
-     *
-     * $this->task('Foo', $a, $b);
-     *
-     * instead of:
-     *
-     * $this->getContainer()->get('taskFoo', [$a, $b]);
-     *
-     * Note that most tasks will define another convenience
-     * function, $this->taskFoo($a, $b), declared in a
-     * 'loadTasks' trait in the task's namespace.  These
-     * 'loadTasks' convenience functions typically will call
-     * $this->task() to ensure that task objects are fetched
-     * from the container, so that their dependencies may be
-     * automatically resolved.
-     */
-    protected function task()
-    {
-        $args = func_get_args();
-        $name = array_shift($args);
-        // We'll allow callers to include the literal 'task'
-        // or not, as they wish; however, the container object
-        // that we fetch must always begin with 'task'
-        if (!preg_match('#^task#', $name)) {
-            $name = "task$name";
-        }
-        return $this->getContainer()->get($name, $args);
     }
 }


### PR DESCRIPTION
Add the 'task' convenience method to BaseTask (by way of `use TaskAccessor`), so that Tasks as well as commands (RoboFiles) will be able to use the `$this->task('Foo', $a, $b);` shortcut.

Makes the code easier to read, too.