### PR TITLE
Decouple progress bar from tasks that use them

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -304,16 +304,19 @@ class RoboFile extends \Robo\Tasks
     /**
      * Test parallel execution
      */
-    public function tryPara($options = ['printed' => false])
+    public function tryPara($options = ['printed' => false, 'error' => false])
     {
         $dir = __DIR__;
-        $this->taskParallelExec()
+        $para = $this->taskParallelExec()
+            ->printed($options['printed'])
             ->process("php $dir/tests/_data/parascript.php hey 4")
             ->process("php $dir/tests/_data/parascript.php hoy 3")
             ->process("php $dir/tests/_data/parascript.php gou 2")
-            ->process("php $dir/tests/_data/parascript.php die 1")
-            ->printed($options['printed'])
-            ->run();
+            ->process("php $dir/tests/_data/parascript.php die 1");
+        if ($options['error']) {
+            $para->process("ls $dir/tests/_data/filenotfound");
+        }
+        $para->run();
     }
 
     public function tryOptbool($opts = ['silent|s' => false])

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -304,13 +304,15 @@ class RoboFile extends \Robo\Tasks
     /**
      * Test parallel execution
      */
-    public function tryPara()
+    public function tryPara($options = ['printed' => false])
     {
+        $dir = __DIR__;
         $this->taskParallelExec()
-            ->process('php ~/demos/robotests/parascript.php hey')
-            ->process('php ~/demos/robotests/parascript.php hoy')
-            ->process('php ~/demos/robotests/parascript.php gou')
-            ->process('php ~/demos/robotests/parascript.php die')
+            ->process("php $dir/tests/_data/parascript.php hey 4")
+            ->process("php $dir/tests/_data/parascript.php hoy 3")
+            ->process("php $dir/tests/_data/parascript.php gou 2")
+            ->process("php $dir/tests/_data/parascript.php die 1")
+            ->printed($options['printed'])
             ->run();
     }
 

--- a/src/Common/ProgressIndicatorAwareTrait.php
+++ b/src/Common/ProgressIndicatorAwareTrait.php
@@ -39,6 +39,10 @@ trait ProgressIndicatorAwareTrait
         }
     }
 
+    public function inProgress() {
+        return $this->progressIndicatorRunning;
+    }
+
     public function stopProgressIndicator()
     {
         $this->stopTimer();

--- a/src/Common/ProgressIndicatorAwareTrait.php
+++ b/src/Common/ProgressIndicatorAwareTrait.php
@@ -1,0 +1,59 @@
+<?php
+namespace Robo\Common;
+
+trait ProgressIndicatorAwareTrait
+{
+    use Timer;
+
+    protected $progressIndicator;
+    protected $progressIndicatorRunning = false;
+
+    public function setProgressIndicator($progressIndicator)
+    {
+        $this->progressIndicator = $progressIndicator;
+    }
+
+    public function hideProgressIndicator()
+    {
+        if ($this->progressIndicatorRunning) {
+            $this->progressIndicator->clear();
+            // Hack: progress indicator does not reset cursor to beginning of line on 'clear'
+            \Robo\Config::output()->write("\x0D");
+        }
+    }
+
+    public function showProgressIndicator()
+    {
+        if ($this->progressIndicatorRunning) {
+            $this->progressIndicator->display();
+        }
+    }
+
+    public function startProgressIndicator($totalSteps = 0)
+    {
+        $this->startTimer();
+        if (isset($this->progressIndicator)) {
+            $this->progressIndicator->start($totalSteps);
+            $this->progressIndicator->display();
+            $this->progressIndicatorRunning = true;
+        }
+    }
+
+    public function stopProgressIndicator()
+    {
+        $this->stopTimer();
+        if ($this->progressIndicatorRunning) {
+            $this->progressIndicatorRunning = false;
+            $this->progressIndicator->finish();
+            // Hack: progress indicator does not always finish cleanly
+            \Robo\Config::output()->writeln('');
+        }
+    }
+
+    public function advanceProgressIndicator($steps = 1)
+    {
+        if ($this->progressIndicatorRunning) {
+            $this->progressIndicator->advance($steps);
+        }
+    }
+}

--- a/src/Common/TaskIO.php
+++ b/src/Common/TaskIO.php
@@ -6,6 +6,8 @@ use Robo\TaskInfo;
 use Consolidation\Log\ConsoleLogLevel;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Robo\Contract\ProgressIndicatorAwareInterface;
 
 /**
  * Task input/output methods.  TaskIO is 'used' in BaseTask, so any
@@ -51,7 +53,7 @@ trait TaskIO
         // The 'note' style is used for both 'notice' and 'info' log levels;
         // However, 'notice' is printed at VERBOSITY_NORMAL, whereas 'info'
         // is only printed at VERBOSITY_VERBOSE.
-        $this->logger()->notice($text, $this->getTaskContext($context));
+        $this->printTaskOutput(LogLevel::NOTICE, $text, $this->getTaskContext($context));
     }
 
     /**
@@ -68,7 +70,7 @@ trait TaskIO
         // override in the context so that this message will be
         // logged as SUCCESS if that log level is recognized.
         $context['_level'] = ConsoleLogLevel::SUCCESS;
-        $this->logger()->notice($text, $this->getTaskContext($context));
+        $this->printTaskOutput(LogLevel::NOTICE, $text, $this->getTaskContext($context));
     }
 
     /**
@@ -79,7 +81,7 @@ trait TaskIO
      */
     protected function printTaskWarning($text, $context = null)
     {
-        $this->logger()->warning($text, $this->getTaskContext($context));
+        $this->printTaskOutput(LogLevel::WARNING, $text, $this->getTaskContext($context));
     }
 
     /**
@@ -90,7 +92,7 @@ trait TaskIO
      */
     protected function printTaskError($text, $context = null)
     {
-        $this->logger()->error($text, $this->getTaskContext($context));
+        $this->printTaskOutput(LogLevel::ERROR, $text, $this->getTaskContext($context));
     }
 
     /**
@@ -99,7 +101,18 @@ trait TaskIO
      */
     protected function printTaskDebug($text, $context = null)
     {
-        $this->logger()->debug($text, $this->getTaskContext($context));
+        $this->printTaskOutput(LogLevel::DEBUG, $text, $this->getTaskContext($context));
+    }
+
+    private function printTaskOutput($level, $text, $context)
+    {
+        if ($this instanceof ProgressIndicatorAwareInterface) {
+            $this->hideProgressIndicator();
+        }
+        $this->logger()->log($level, $text, $this->getTaskContext($context));
+        if ($this instanceof ProgressIndicatorAwareInterface) {
+            $this->showProgressIndicator();
+        }
     }
 
     /**

--- a/src/Common/TaskIO.php
+++ b/src/Common/TaskIO.php
@@ -106,11 +106,19 @@ trait TaskIO
 
     private function printTaskOutput($level, $text, $context)
     {
+        $inProgress = false;
         if ($this instanceof ProgressIndicatorAwareInterface) {
+            $inProgress = $this->inProgress();
+        }
+
+        // If a progress indicator is running on this task, then we mush
+        // hide it before we print anything, or its display will be overwritten.
+        if ($inProgress) {
             $this->hideProgressIndicator();
         }
         $this->logger()->log($level, $text, $this->getTaskContext($context));
-        if ($this instanceof ProgressIndicatorAwareInterface) {
+        // After we have printed our log message, redraw the progress indicator.
+        if ($inProgress) {
             $this->showProgressIndicator();
         }
     }

--- a/src/Contract/ProgressIndicatorAwareInterface.php
+++ b/src/Contract/ProgressIndicatorAwareInterface.php
@@ -1,0 +1,21 @@
+<?php
+namespace Robo\Contract;
+
+/**
+ * Any Robo task that uses the Timer trait and
+ * implements ProgressIndicatorAwareInterface will
+ * display a progress bar while the timer is running.
+ * Call advanceProgressIndicator to advance the indicator.
+ *
+ * Interface ProgressIndicatorAwareInterface
+ * @package Robo\Contract
+ */
+interface ProgressIndicatorAwareInterface
+{
+    public function setProgressIndicator($progressIndicator);
+    public function startProgressIndicator($totalSteps = 0);
+    public function stopProgressIndicator();
+    public function hideProgressIndicator();
+    public function showProgressIndicator();
+    public function advanceProgressIndicator($steps = 1);
+}

--- a/src/Contract/ProgressIndicatorAwareInterface.php
+++ b/src/Contract/ProgressIndicatorAwareInterface.php
@@ -13,6 +13,7 @@ namespace Robo\Contract;
 interface ProgressIndicatorAwareInterface
 {
     public function setProgressIndicator($progressIndicator);
+    public function inProgress();
     public function startProgressIndicator($totalSteps = 0);
     public function stopProgressIndicator();
     public function hideProgressIndicator();

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -150,6 +150,8 @@ class Runner
         $container->share('logger', \Robo\Log\RoboLogger::class)
             ->withArgument('output')
             ->withMethodCall('setLogOutputStyler', ['logStyler']);
+        $container->add('progressIndicator', \Symfony\Component\Console\Helper\ProgressBar::class)
+            ->withArgument('output');
         $container->share('resultPrinter', \Robo\Log\ResultPrinter::class);
         $container->add('simulator', \Robo\Task\Simulator::class);
         $container->share('globalOptionsEventListener', \Robo\GlobalOptionsEventListener::class);
@@ -163,6 +165,8 @@ class Runner
             ->invokeMethod('setContainer', ['container']);
         $container->inflector(\Symfony\Component\Console\Input\InputAwareInterface::class)
             ->invokeMethod('setInput', ['input']);
+        $container->inflector(\Robo\Contract\ProgressIndicatorAwareInterface::class)
+            ->invokeMethod('setProgressIndicator', ['progressIndicator']);
     }
 
     /**

--- a/src/Task/Base/ParallelExec.php
+++ b/src/Task/Base/ParallelExec.php
@@ -88,6 +88,7 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
                 try {
                     $process->checkTimeout();
                 } catch (ProcessTimedOutException $e) {
+                    $this->printTaskWarning("Process timed out for {command}", ['command' => $process->getCommandLine(), '_style' => ['command' => 'fg=white;bg=magenta']]);
                 }
                 if (!$process->isRunning()) {
                     $this->advanceProgressIndicator();

--- a/src/Task/Base/ParallelExec.php
+++ b/src/Task/Base/ParallelExec.php
@@ -93,8 +93,9 @@ class ParallelExec extends BaseTask implements CommandInterface, PrintedInterfac
                     $this->advanceProgressIndicator();
                     if ($this->isPrinted) {
                         $this->printTaskInfo("Output for {command}:\n\n{output}", ['command' => $process->getCommandLine(), 'output' => $process->getOutput(), '_style' => ['command' => 'fg=white;bg=magenta']]);
-                        if ($process->getErrorOutput()) {
-                            $this->getOutput()->writeln("<error>" . $process->getErrorOutput() . "</error>");
+                        $errorOutput = $process->getErrorOutput();
+                        if ($errorOutput) {
+                            $this->printTaskError(rtrim($errorOutput));
                         }
                     }
                     unset($running[$k]);

--- a/tests/_data/parascript.php
+++ b/tests/_data/parascript.php
@@ -1,0 +1,8 @@
+<?php
+
+$message = $argv[1];
+$iterations = $argv[2];
+for ($i=0; $i < $iterations; ++$i) {
+    print "$message\n";
+    sleep(1);
+}


### PR DESCRIPTION
Tasks can now `implement ProgressIndicatorAwareInterface ` and `use ProgressIndicatorAwareTrait` to have access to a progress bar without having a direct reference to IO or an output object.

The task must still call `startProgressIndicator()` & c. to make the progress indicator go, of course. If the DI container does not have a progress bar, though, then these calls will be no-ops, so programs that do not provide progress displays may still use tasks that utilize them.

The TaskIO trait is aware of the progress interface, and will automatically hide and then re-show the progress bar if a task uses one of the `printTaskInfo` methods to produce output while the progress bar is running.

Note that ProgressIndicatorAwareTrait has a `use Timer` and manages the timer automatically.  Nearly automatically, anyway; tasks must still insert `['time' => $this->getExecutionTime()]` into their Result manually.

Note that I added a `parascript.php` script in the test data, and call it from RoboFile::tryPara().  There is a --printed option, so you can see parallel execution with or without the command output of each subprocess.

There are a couple of minor hacks in ProgressIndicatorAwareTrait to work around behaviors of the upstream. We could also fix these by subclassing the ProgressBar, but I think it would be sufficient to leave it like this for now, & eventually fix in the upstream.