### PR TITLE
Introduce TaskInterface and Callable variants for Collection methods

### DIFF
--- a/src/Collection/CallableTask.php
+++ b/src/Collection/CallableTask.php
@@ -16,7 +16,7 @@ class CallableTask implements TaskInterface
 {
     private $fn;
 
-    public function __construct($fn)
+    public function __construct(callable $fn)
     {
         $this->fn = $fn;
     }

--- a/src/Collection/CallableTask.php
+++ b/src/Collection/CallableTask.php
@@ -14,11 +14,13 @@ use Robo\Collection\Collection;
  */
 class CallableTask implements TaskInterface
 {
-    private $fn;
+    protected $fn;
+    protected $reference;
 
-    public function __construct(callable $fn)
+    public function __construct(callable $fn, TaskInterface $reference)
     {
         $this->fn = $fn;
+        $this->reference = $reference;
     }
 
     public function run()
@@ -33,7 +35,7 @@ class CallableTask implements TaskInterface
         // a \Robo\Result or an exit code.  In the later case, we
         // convert it to a \Robo\Result.
         if (!$result instanceof Result) {
-            $result = new Result($this, $result);
+            $result = new Result($this->reference, $result);
         }
 
         return $result;

--- a/src/Collection/Collectable.php
+++ b/src/Collection/Collectable.php
@@ -2,6 +2,8 @@
 
 namespace Robo\Collection;
 
+use Robo\Contract\TaskInterface;
+
 /**
  * The 'Collectable' trait is used by Robo\Task\BaseTask, so all Robo
  * tasks are collectable.
@@ -33,9 +35,9 @@ trait Collectable
         return $this->addCollectableToCollection($collection->ignoreErrorsTaskWrapper($this), $collection, $taskName);
     }
 
-    private function addCollectableToCollection($task, Collection $collection, $taskName = Collection::UNNAMEDTASK, TaskInterface $rollbackTask = null)
+    private function addCollectableToCollection(TaskInterface $task, Collection $collection, $taskName = Collection::UNNAMEDTASK, TaskInterface $rollbackTask = null)
     {
-        $collection->add($taskName, $task);
+        $collection->add($task, $taskName);
         if ($rollbackTask) {
             $collection->rollback($rollbackTask);
         }

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -147,7 +147,7 @@ class Collection implements TaskInterface, ContainerAwareInterface
         $collection = $this;
         $completionRegistrationTask = new CallableTask(
             function () use ($collection, $completionTask) {
-            
+
                 $collection->registerCompletion($completionTask);
             },
             $this
@@ -380,16 +380,6 @@ class Collection implements TaskInterface, ContainerAwareInterface
         if ($completionTask) {
             // Completion tasks always try as hard as they can, and never report failures.
             $completionTask = $this->ignoreErrorsTaskWrapper($completionTask);
-            $this->completionStack[] = $completionTask;
-        }
-        return $this;
-    }
-
-    public function registerCompletionCode(callable $completionTask)
-    {
-        if ($completionTask) {
-            // Completion tasks always try as hard as they can, and never report failures.
-            $completionTask = $this->ignoreErrorsCodeWrapper($completionTask);
             $this->completionStack[] = $completionTask;
         }
         return $this;

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -77,30 +77,22 @@ class Collection implements TaskInterface, ContainerAwareInterface
      * method ONLY if its 'run()' method completes successfully, and some
      * task added after it fails.
      *
-     * @param string|TaskInterface|TaskInterface[]
-     *   An optional name for the task -- missing or NULL for unnamed tasks.
-     *   Names are used for positioning before and after tasks.  If
-     *   a name is not provided, then the first parameter may contain
-     *   a task to add, or an array of tasks to add.
      * @param TaskInterface
-     *   If the first parameter is a string, then the second parameter
-     *   holds a single task to add to our collection.
+     *   The task to add to our collection.
+     * @param string
+     *   An optional name for the task -- missing or UNNAMEDTASK for unnamed tasks.
+     *   Names are used for positioning before and after tasks.
      */
-    public function add($name, $task = null)
+    public function add(TaskInterface $task, $name = self::UNNAMEDTASK)
     {
-        // If '$name' was unspecified, then the single parameter provided
-        // is the task or Callable object.  Make $name 'UNNAMEDTASK'.
-        if (!is_string($name) && ($task == null)) {
-            $task = $name;
-            $name = self::UNNAMEDTASK;
-        }
-        // If $task is an array (and isn't a Callable), then add every item
-        // in the array individually.
-        if (!is_callable($task) && is_array($task)) {
-            return $this->addTaskList($task);
-        }
-        // Otherwise, add the named (or unnamed) task.
-        return $this->addTask($name, $task);
+        $task = $this->getContainer()->get('completionWrapper', [$this, $task]);
+        $this->addToTaskStack($name, $task);
+        return $this;
+    }
+
+    public function addCode(callable $task, $name = self::UNNAMEDTASK)
+    {
+        return $this->add(new CallableTask($task, $this), $name);
     }
 
     /**
@@ -113,14 +105,29 @@ class Collection implements TaskInterface, ContainerAwareInterface
      *   task executes, not its 'rollback()' method.  To use the 'rollback()'
      *   method, add the task via 'Collection::add()' instead.
      */
-    public function rollback($rollbackTask)
+    public function rollback(TaskInterface $rollbackTask)
     {
         // Rollback tasks always try as hard as they can, and never report failures.
         $rollbackTask = $this->ignoreErrorsTaskWrapper($rollbackTask);
+        return $this->wrapAndRegisterRollback($rollbackTask);
+    }
+
+    public function rollbackCode(callable $rollbackTask)
+    {
+        // Rollback tasks always try as hard as they can, and never report failures.
+        $rollbackTask = $this->ignoreErrorsCodeWrapper($rollbackTask);
+        return $this->wrapAndRegisterRollback($rollbackTask);
+    }
+
+    protected function wrapAndRegisterRollback(TaskInterface $rollbackTask)
+    {
         $collection = $this;
-        $rollbackRegistrationTask = $this->wrapTask(function () use ($collection, $rollbackTask) {
-            $collection->registerRollback($rollbackTask);
-        });
+        $rollbackRegistrationTask = new CallableTask(
+            function () use ($collection, $rollbackTask) {
+                $collection->registerRollback($rollbackTask);
+            },
+            $this
+        );
         $this->addToTaskStack(self::UNNAMEDTASK, $rollbackRegistrationTask);
         return $this;
     }
@@ -135,16 +142,24 @@ class Collection implements TaskInterface, ContainerAwareInterface
      *   The completion task to add.  Note that the 'run()' method of the
      *   task executes, just as if the task was added normally.
      */
-    public function completion($completionTask)
+    public function completion(TaskInterface $completionTask)
     {
-        // Wrap the task as necessary.
-        $completionTask = $this->wrapTask($completionTask);
         $collection = $this;
-        $completionRegistrationTask = $this->wrapTask(function () use ($collection, $completionTask) {
-            $collection->registerCompletion($completionTask);
-        });
+        $completionRegistrationTask = new CallableTask(
+            function () use ($collection, $completionTask) {
+            
+                $collection->registerCompletion($completionTask);
+            },
+            $this
+        );
         $this->addToTaskStack(self::UNNAMEDTASK, $completionRegistrationTask);
         return $this;
+    }
+
+    public function completionCode(callable $completionTask)
+    {
+        $completionTask = new CallableTask($completionTask, $this);
+        return $this->completion($completionTask);
     }
 
     /**
@@ -158,13 +173,17 @@ class Collection implements TaskInterface, ContainerAwareInterface
      *   The name of the task to add. If not provided, will be associated
      *   with the named task it was added before.
      */
-    public function before($name, $task, $nameOfTaskToAdd = self::UNNAMEDTASK)
+    public function before($name, TaskInterface $task, $nameOfTaskToAdd = self::UNNAMEDTASK)
     {
-        // Wrap the task as necessary.
-        $task = $this->wrapTask($task);
         $existingTask = $this->namedTask($name);
         $existingTask->before($task, $nameOfTaskToAdd);
         return $this;
+    }
+
+    public function beforeCode($name, callable $task, $nameOfTaskToAdd = self::UNNAMEDTASK)
+    {
+        $task = new CallableTask($task, $this);
+        return $this->before($name, $task, $nameOfTaskToAdd);
     }
 
     /**
@@ -178,13 +197,17 @@ class Collection implements TaskInterface, ContainerAwareInterface
      *   The name of the task to add. If not provided, will be associated
      *   with the named task it was added after.
      */
-    public function after($name, $task, $nameOfTaskToAdd = self::UNNAMEDTASK)
+    public function after($name, TaskInterface $task, $nameOfTaskToAdd = self::UNNAMEDTASK)
     {
-        // Wrap the task as necessary.
-        $task = $this->wrapTask($task);
         $existingTask = $this->namedTask($name);
         $existingTask->after($task, $nameOfTaskToAdd);
         return $this;
+    }
+
+    public function afterCode($name, callable $task, $nameOfTaskToAdd = self::UNNAMEDTASK)
+    {
+        $task = new CallableTask($task, $this);
+        return $this->after($name, $task, $nameOfTaskToAdd);
     }
 
     /**
@@ -198,7 +221,7 @@ class Collection implements TaskInterface, ContainerAwareInterface
      * are ignored, so that 'file not found' may be ignored,
      * but 'permission denied' reported?
      */
-    public function ignoreErrorsTaskWrapper($task)
+    public function ignoreErrorsTaskWrapper(TaskInterface $task)
     {
         // If the task is a stack-based task, then tell it
         // to try to run all of its operations, even if some
@@ -206,9 +229,6 @@ class Collection implements TaskInterface, ContainerAwareInterface
         if ($task instanceof StackBasedTask) {
             $task->stopOnFail(false);
         }
-        // If the task that was provided to us is a
-        // callable, then wrap it in a task.
-        $task = $this->wrapTask($task);
         $ignoreErrorsInTask = function () use ($task) {
             $data = [];
             try {
@@ -223,7 +243,12 @@ class Collection implements TaskInterface, ContainerAwareInterface
             return Result::success($task, $message, $data);
         };
         // Wrap our ignore errors callable in a task.
-        return $this->wrapTask($ignoreErrorsInTask);
+        return new CallableTask($ignoreErrorsInTask, $this);
+    }
+
+    public function ignoreErrorsCodeWrapper(callable $task)
+    {
+        return $this->ignoreErrorsTaskWrapper(new CallableTask($task, $this));
     }
 
     /**
@@ -273,59 +298,23 @@ class Collection implements TaskInterface, ContainerAwareInterface
     }
 
     /**
-     * Add a list of tasks to our task collection. This is
-     * protected because clients should just call 'add()'.
+     * Add a list of tasks to our task collection.
      *
      * @param TaskInterface[]
      *   An array of tasks to run with rollback protection
      */
-    protected function addTaskList($tasks)
+    public function addTaskList(array $tasks)
     {
         foreach ($tasks as $name => $task) {
-            $this->addTask($name, $task);
+            $this->add($task, $name);
         }
         return $this;
-    }
-
-    /**
-     * Add a task to our task collection.  If there is a later failure,
-     * then run the provided rollback operation.  The rollback() method of
-     * the task will also be executed, if the task implements
-     * RollbackInterface.  addTask is protected because clients should
-     * just call 'add()'.
-     *
-     * @param string
-     *   A name for the task, used for positioning before and after tasks.
-     * @param TaskInterface
-     *   The task to run
-     */
-    protected function addTask($name, $task)
-    {
-        // Wrap the task as necessary.
-        $task = $this->wrapTask($task);
-        $task = $this->getContainer()->get('completionWrapper', [$this, $task]);
-        $this->addToTaskStack($name, $task);
-        return $this;
-    }
-
-    /**
-     * If the task needs to be wrapped, create whatever wrapper objects are
-     * needed for it.
-     */
-    protected function wrapTask($task)
-    {
-        // If the caller provided a function pointer instead of a TaskInstance,
-        // then wrap it in a CallableTask.
-        if (is_callable($task)) {
-            $task = new CallableTask($task, $this);
-        }
-        return $task;
     }
 
     /**
      * Add the provided task to our task list.
      */
-    protected function addToTaskStack($name, $task)
+    protected function addToTaskStack($name, TaskInterface $task)
     {
         // All tasks are stored in a task group so that we have a place
         // to hang 'before' and 'after' tasks.
@@ -360,10 +349,8 @@ class Collection implements TaskInterface, ContainerAwareInterface
      * @param TaskInterface
      *   The rollback task to run on failure.
      */
-    public function registerRollback($rollbackTask)
+    public function registerRollback(TaskInterface $rollbackTask)
     {
-        // Wrap the task as necessary.
-        $rollbackTask = $this->wrapTask($rollbackTask);
         if ($rollbackTask) {
             $this->rollbackStack[] = $rollbackTask;
         }
@@ -388,11 +375,21 @@ class Collection implements TaskInterface, ContainerAwareInterface
      * @param TaskInterface
      *   The completion task to run at the end of all other operations.
      */
-    public function registerCompletion($completionTask)
+    public function registerCompletion(TaskInterface $completionTask)
     {
         if ($completionTask) {
             // Completion tasks always try as hard as they can, and never report failures.
             $completionTask = $this->ignoreErrorsTaskWrapper($completionTask);
+            $this->completionStack[] = $completionTask;
+        }
+        return $this;
+    }
+
+    public function registerCompletionCode(callable $completionTask)
+    {
+        if ($completionTask) {
+            // Completion tasks always try as hard as they can, and never report failures.
+            $completionTask = $this->ignoreErrorsCodeWrapper($completionTask);
             $this->completionStack[] = $completionTask;
         }
         return $this;
@@ -488,7 +485,7 @@ class Collection implements TaskInterface, ContainerAwareInterface
      * Run every task in a list, but only up to the first failure.
      * Return the failing result, or success if all tasks run.
      */
-    protected function runTaskList($name, $taskList, $result)
+    protected function runTaskList($name, array $taskList, $result)
     {
         try {
             foreach ($taskList as $taskName => $task) {
@@ -544,7 +541,7 @@ class Collection implements TaskInterface, ContainerAwareInterface
      * Run all of the tasks in a provided list, ignoring failures.
      * This is used to roll back or complete.
      */
-    protected function runTaskListIgnoringFailures($taskList)
+    protected function runTaskListIgnoringFailures(array $taskList)
     {
         foreach ($taskList as $task) {
             try {

--- a/src/Collection/CompletionWrapper.php
+++ b/src/Collection/CompletionWrapper.php
@@ -61,10 +61,10 @@ class CompletionWrapper extends BaseTask implements WrappedTaskInterface
             $this->collection->registerRollback($this->rollbackTask);
         }
         if ($this->task instanceof RollbackInterface) {
-            $this->collection->registerRollbackCode([$this->task, 'rollback']);
+            $this->collection->registerRollback(new CallableTask([$this->task, 'rollback'], $this->task));
         }
         if ($this->task instanceof CompletionInterface) {
-            $this->collection->registerCompletionCode([$this->task, 'complete']);
+            $this->collection->registerCompletion(new CallableTask([$this->task, 'complete'], $this->task));
         }
 
         return $this->task->run();

--- a/src/Collection/CompletionWrapper.php
+++ b/src/Collection/CompletionWrapper.php
@@ -61,10 +61,10 @@ class CompletionWrapper extends BaseTask implements WrappedTaskInterface
             $this->collection->registerRollback($this->rollbackTask);
         }
         if ($this->task instanceof RollbackInterface) {
-            $this->collection->registerRollback([$this->task, 'rollback']);
+            $this->collection->registerRollbackCode([$this->task, 'rollback']);
         }
         if ($this->task instanceof CompletionInterface) {
-            $this->collection->registerCompletion([$this->task, 'complete']);
+            $this->collection->registerCompletionCode([$this->task, 'complete']);
         }
 
         return $this->task->run();

--- a/src/Contract/CompletionInterface.php
+++ b/src/Contract/CompletionInterface.php
@@ -9,7 +9,7 @@ namespace Robo\Contract;
  * Interface CompletionInterface
  * @package Robo\Contract
  */
-interface CompletionInterface
+interface CompletionInterface extends TaskInterface
 {
     /**
      * Revert an operation that can be rolled back

--- a/src/Contract/RollbackInterface.php
+++ b/src/Contract/RollbackInterface.php
@@ -9,7 +9,7 @@ namespace Robo\Contract;
  * Interface RollbackInterface
  * @package Robo\Contract
  */
-interface RollbackInterface
+interface RollbackInterface extends TaskInterface
 {
     /**
      * Revert an operation that can be rolled back

--- a/src/Contract/WrappedTaskInterface.php
+++ b/src/Contract/WrappedTaskInterface.php
@@ -1,7 +1,7 @@
 <?php
 namespace Robo\Contract;
 
-interface WrappedTaskInterface
+interface WrappedTaskInterface extends TaskInterface
 {
     /**
      * @return \Robo\Contract\TaskInterface

--- a/tests/cli/CollectionCest.php
+++ b/tests/cli/CollectionCest.php
@@ -183,7 +183,7 @@ class CollectionCest
         // Now, rather than creating a series of tasks and adding them
         // all with addToCollection(), we will add them directly to the collection
         // via the add() method.
-        $result = $collection->add(
+        $result = $collection->addTaskList(
             [
                 $I->taskFileSystemStack()->mkdir("$tmpPath/log")->touch("$tmpPath/log/error.txt"),
                 $I->taskCopyDir([$tmpPath => 'copied3']),

--- a/tests/unit/Task/CollectionTest.php
+++ b/tests/unit/Task/CollectionTest.php
@@ -37,11 +37,11 @@ class CollectionTest extends \Codeception\TestCase\Test
         // after tasks. These methods have access to the task
         // class' fields, and may modify them as needed.
         $collection
-            ->afterCode('a-name', [$taskA, 'parenthesizer'])
-            ->afterCode('a-name', [$taskA, 'emphasizer'])
-            ->afterCode('b-name', [$taskB, 'emphasizer'])
-            ->afterCode('b-name', [$taskB, 'parenthesizer'])
-            ->afterCode('b-name', [$taskB, 'parenthesizer'], 'special-name');
+            ->after('a-name', [$taskA, 'parenthesizer'])
+            ->after('a-name', [$taskA, 'emphasizer'])
+            ->after('b-name', [$taskB, 'emphasizer'])
+            ->after('b-name', [$taskB, 'parenthesizer'])
+            ->after('b-name', [$taskB, 'parenthesizer'], 'special-name');
 
         $result = $collection->run();
 

--- a/tests/unit/Task/CollectionTest.php
+++ b/tests/unit/Task/CollectionTest.php
@@ -30,18 +30,18 @@ class CollectionTest extends \Codeception\TestCase\Test
         $taskB = new CollectionTestTask('b', 'value-b');
 
         $collection
-            ->add('a-name', $taskA)
-            ->add('b-name', $taskB);
+            ->add($taskA, 'a-name')
+            ->add($taskB, 'b-name');
 
         // We add methods of our task instances as before and
         // after tasks. These methods have access to the task
         // class' fields, and may modify them as needed.
         $collection
-            ->after('a-name', [$taskA, 'parenthesizer'])
-            ->after('a-name', [$taskA, 'emphasizer'])
-            ->after('b-name', [$taskB, 'emphasizer'])
-            ->after('b-name', [$taskB, 'parenthesizer'])
-            ->after('b-name', [$taskB, 'parenthesizer'], 'special-name');
+            ->afterCode('a-name', [$taskA, 'parenthesizer'])
+            ->afterCode('a-name', [$taskA, 'emphasizer'])
+            ->afterCode('b-name', [$taskB, 'emphasizer'])
+            ->afterCode('b-name', [$taskB, 'parenthesizer'])
+            ->afterCode('b-name', [$taskB, 'parenthesizer'], 'special-name');
 
         $result = $collection->run();
 


### PR DESCRIPTION
And add appropriate type hints to all of them.

Originally, the Collection API was designed to allow clients to just call `add()` on whatever sort of object they had available. However, it is a common pattern to have things such as a `setCode()` method (e.g. Symfony's `Command::setCode()`); I followed this pattern to create `addCode()` et. al., and added typehints to all of these functions.

I don't think there are any (or many) users of Collections right now; if there are any clients that do need to adapt, the typehints will make it easy to figure out what changes are needed.

I think it's important to do this before our stable release; should have been typehinted in the first place.