### PR TITLE
Add a Collection::progressMessage() method

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -111,6 +111,7 @@ class RoboFile extends \Robo\Tasks
     public function docs()
     {
         $collection = $this->collection();
+        $collection->progressMessage('Generate documentation from source code.');
         $files = Finder::create()->files()->name('*.php')->in('src/Task');
         $docs = [];
         foreach ($files as $file) {
@@ -168,6 +169,7 @@ class RoboFile extends \Robo\Tasks
                 }
             )->addToCollection($collection);
         }
+        $collection->progressMessage('Documentation generation complete.');
         $collection->run();
     }
 

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -116,8 +116,7 @@ class Collection implements TaskInterface, LoggerAwareInterface, ContainerAwareI
         $context += ['name' => 'Progress'];
         $context += TaskInfo::getTaskContext($this);
         return $this->addCode(
-            function () use ($level, $text, $context, $logger)
-            {
+            function () use ($level, $text, $context, $logger) {
                 $logger->log($level, $text, $context);
             }
         );

--- a/src/Common/TaskIO.php
+++ b/src/Common/TaskIO.php
@@ -104,7 +104,7 @@ trait TaskIO
         $this->printTaskOutput(LogLevel::DEBUG, $text, $this->getTaskContext($context));
     }
 
-    private function printTaskOutput($level, $text, $context)
+    protected function printTaskOutput($level, $text, $context)
     {
         $inProgress = false;
         if ($this instanceof ProgressIndicatorAwareInterface) {


### PR DESCRIPTION
Allows Collection clients to insert log messages into the task stream.

Note that this PR branches from #307, since it is based on some API changes made there.