### PR TITLE
Do not suggest wildcard in composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ Now you can use it just like `robo`.
 
 ### Composer
 
-* Add `"codegyre/robo": "*"` to `composer.json`.
-* Run `composer install`
+* Run `composer require codegyre/robo`
 * Use `vendor/bin/robo` to execute Robo tasks.
 
 ## Usage


### PR DESCRIPTION
You should not suggest using `*` wildcard when requiring a package. This is a bad practice and prevents from breaking BC in major versions, making semver useless