### PR TITLE
Fix the visibility of the Result::$stopOnFail property

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -9,7 +9,7 @@ use Consolidation\AnnotationCommand\ExitCodeInterface;
 
 class Result implements \ArrayAccess, \IteratorAggregate, ExitCodeInterface
 {
-    protected static $stopOnFail = false;
+    public static $stopOnFail = false;
 
     protected $exitCode;
     protected $message;


### PR DESCRIPTION
The "protected" visibility causes src/Tasks.php#L16 to throw exceptions (PHP Fatal error: Uncaught Error: Cannot access protected property Robo\Result::$stopOnFail in vendor/codegyre/robo/src/Tasks.php:16)  