### PR TITLE
Remove $data['output'] from ResultData, and use $message consistently.

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -418,7 +418,8 @@ class RoboFile extends \Robo\Tasks
             [ 'first' => 'Ichi', 'second' => 'Ni',   'third' => 'San'   ],
             [ 'first' => 'Uno',  'second' => 'Dos',  'third' => 'Tres'  ],
         ];
-        return ResultData::outputData($outputData);
+        // Note that we can also simply return the output data array here.
+        return ResultData::message($outputData);
     }
 
     /**

--- a/src/ResultData.php
+++ b/src/ResultData.php
@@ -31,11 +31,9 @@ class ResultData implements \ArrayAccess, \IteratorAggregate, ExitCodeInterface,
         $this->data = $data;
     }
 
-    public static function outputData($outputData, $data = [])
+    public static function message($message, $data = [])
     {
-        $result = new self(self::EXITCODE_OK, '', $data);
-        $result->setOutputData($outputData);
-        return $result;
+        return new self(self::EXITCODE_OK, $message, $data);
     }
 
     public static function cancelled($message = '', $data = [])
@@ -61,18 +59,9 @@ class ResultData implements \ArrayAccess, \IteratorAggregate, ExitCodeInterface,
 
     public function getOutputData()
     {
-        if (isset($this->data['output'])) {
-            return $this->data['output'];
+        if (!empty($this->message) && !array_key_exists('already-printed', $this->data)) {
+            return $this->message;
         }
-        $message = $this->getMessage();
-        if (!empty($message) && !array_key_exists('already-printed', $this->data)) {
-            return $message;
-        }
-    }
-
-    public function setOutputData($outputData)
-    {
-        $this->data['output'] = $outputData;
     }
 
     /**


### PR DESCRIPTION
After reflecting a bit more on #309, I decided that it would be much better and clearer to use `$message` consistently, and avoid introducing `$data['output']`. This PR reflects that change.