### PR TITLE
Adds initial new changelog task

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "symfony/finder": "~2.5|~3.0",
         "symfony/console": "~2.5|~3.0",
         "symfony/process": "~2.5|~3.0",
-        "symfony/filesystem": "~2.5|~3.0"
+        "symfony/filesystem": "~2.5|~3.0",
+        "stevewest/changelog": "^1.2"
     },
     "require-dev": {
         "patchwork/jsqueeze": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "47d96195ac8c5a6c6db7eac4b931cc15",
-    "content-hash": "b572c4af89fca3e726aa28a6ee12bda1",
+    "hash": "b34fea12d296f13b11dee674e26ece6b",
+    "content-hash": "9e473fb983c5697769e0a586af08b052",
     "packages": [
         {
             "name": "consolidation/annotated-command",
@@ -244,6 +244,53 @@
             "time": "2016-03-17 11:07:59"
         },
         {
+            "name": "naneau/semver",
+            "version": "0.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/naneau/semver.git",
+                "reference": "60ea59641aad840f97f3c9057e2f2b7bc087eaa3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/naneau/semver/zipball/60ea59641aad840f97f3c9057e2f2b7bc087eaa3",
+                "reference": "60ea59641aad840f97f3c9057e2f2b7bc087eaa3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Naneau\\SemVer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maurice Fonk",
+                    "email": "maurice@naneau.net",
+                    "homepage": "http://mauricefonk.com",
+                    "role": "developer"
+                }
+            ],
+            "description": "A decent, standards-compliant, Semantic Versioning (SemVer) parser and library",
+            "homepage": "https://github.com/naneau/semver",
+            "keywords": [
+                "semantic",
+                "semver",
+                "versioning"
+            ],
+            "time": "2013-01-04 00:00:00"
+        },
+        {
             "name": "phpdocumentor/reflection-docblock",
             "version": "2.0.4",
             "source": {
@@ -329,6 +376,65 @@
                 "psr-3"
             ],
             "time": "2012-12-21 11:40:51"
+        },
+        {
+            "name": "stevewest/changelog",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stevewest/changelog.git",
+                "reference": "e37aa886e945fc5a7734e26533414b45203c5ece"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stevewest/changelog/zipball/e37aa886e945fc5a7734e26533414b45203c5ece",
+                "reference": "e37aa886e945fc5a7734e26533414b45203c5ece",
+                "shasum": ""
+            },
+            "require": {
+                "naneau/semver": "^0.0.7",
+                "symfony/console": "^3.0"
+            },
+            "require-dev": {
+                "codeception/codeception": "~2.0",
+                "codeception/mockery-module": "dev-master",
+                "codegyre/robo": "^0.7.2",
+                "league/flysystem": "dev-master",
+                "milo/github-api": "dev-master",
+                "php": ">=5.6"
+            },
+            "suggest": {
+                "league/flysystem": "Allows change logs to be read and written to pretty much everywhere.",
+                "milo/github-api": "Allows change logs to be loaded and committed to/from a github repo."
+            },
+            "bin": [
+                "changelog"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ChangeLog\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Steve \"uru\" West",
+                    "email": "steven.david.west@gmail.com"
+                }
+            ],
+            "description": "Package to enable change logs to be parsed",
+            "homepage": "https://github.com/stevewest/changelog",
+            "keywords": [
+                "change",
+                "changelog",
+                "log",
+                "parser"
+            ],
+            "time": "2016-04-23 13:12:11"
         },
         {
             "name": "symfony/console",


### PR DESCRIPTION
Potential new change log task.

Currently this is missing docs, tests and breaks backwards compatibility, I am opening this pull request to gain feedback from any who wish to give it.

Current TODO:
 - [ ] Restore some kind of BC
 - [ ] Update docs with extra features
 - [ ] Add tests

Thoughts/ideas about what else the task can do are welcome, anything to make this more useful.