### PR TITLE
Fixed missing definition of run-method in the docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -419,5 +419,6 @@ class MyTask extends BaseTask implements ProgressIndicatorAwareInterface
         return new Result($this, $exitCode, $errorMessage, ['time' => $this->getExecutionTime()]);
     }
 }
+?>
 ```
 Tasks should not attempt to use a specific progress indicator (e.g. the Symfony ProgressBar class) directly, as the ProgressIndicatorAwareTrait allows for an appropriate progress indicator to be used (or omitted) as best suits the application.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -396,25 +396,28 @@ It is preferable for commands that look up and display information should avoid 
 
 ### Progress
 Long-running tasks that wish to display a progress indicator may do so by way of the ProgressIndicatorAwareTrait.
-```
+``` php
+<?php
 use Robo\Contract\ProgressIndicatorAwareInterface;
 use Robo\Common\ProgressIndicatorAwareTrait;
 
 class MyTask extends BaseTask implements ProgressIndicatorAwareInterface
 {
     use ProgressIndicatorAwareTrait;
-    
-    $exitCode = 0;
-    $steps = 10;
-    $errorMessage = "";
-    
-    $this->startProgressIndicator($steps);
-    for ($i = 0; $i < $steps; ++i) {
-        $this->advanceProgressIndicator();        
-    }
-    $this->stopProgressIndicator();
 
-    return new Result($this, $exitCode, $errorMessage, ['time' => $this->getExecutionTime()]);
+    function run(){
+        $exitCode = 0;
+        $steps = 10;
+        $errorMessage = "";
+    
+        $this->startProgressIndicator($steps);
+        for ($i = 0; $i < $steps; ++$i) {
+            $this->advanceProgressIndicator();
+        }
+        $this->stopProgressIndicator();
+
+        return new Result($this, $exitCode, $errorMessage, ['time' => $this->getExecutionTime()]);
+    }
 }
 ```
 Tasks should not attempt to use a specific progress indicator (e.g. the Symfony ProgressBar class) directly, as the ProgressIndicatorAwareTrait allows for an appropriate progress indicator to be used (or omitted) as best suits the application.


### PR DESCRIPTION
I think there was a missing definition of the run-method in the docs.