### PR TITLE
Use 'Filesystem' rather than 'FileSystem' consistently.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Provide ResultData base class for Result; ResultData may be used in instances where a specific `$task` instance is not available (e.g. in a Robo command)
 * ArgvInput now available via $this->getInput() in RoboFile by Thomas Spigel
 * Add optional message to git tag task by Tim Tegeler
+* Rename 'FileSystem' to 'Filesystem' wherever it occurs.
 
 #### 0.6.0
 

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -20,7 +20,7 @@ use League\Container\ContainerAwareTrait;
  *
  * Below, the example FilesystemStack task is added to a collection,
  * and associated with a rollback task.  If any of the operations in
- * the FileSystemStack, or if any of the other tasks also added to
+ * the FilesystemStack, or if any of the other tasks also added to
  * the task collection should fail, then the rollback function is
  * called. Often, taskDeleteDir is used to remove partial results
  * of an unfinished task.
@@ -28,7 +28,7 @@ use League\Container\ContainerAwareTrait;
  * ``` php
  * <?php
  * $collection = $this->collection();
- * $this->taskFileSystemStack()
+ * $this->taskFilesystemStack()
  *      ->mkdir('logs')
  *      ->touch('logs/.gitignore')
  *      ->chgrp('logs', 'www-data')

--- a/src/Collection/CompletionWrapper.php
+++ b/src/Collection/CompletionWrapper.php
@@ -17,7 +17,7 @@ use Robo\Contract\WrappedTaskInterface;
  * creates temporary objects.  This is usually best done via
  * Temporary::wrap().
  *
- * @see Robo\Task\FileSystem\loadTasks::taskTmpDir
+ * @see Robo\Task\Filesystem\loadTasks::taskTmpDir
  */
 class CompletionWrapper extends BaseTask implements WrappedTaskInterface
 {

--- a/src/LoadAllTasks.php
+++ b/src/LoadAllTasks.php
@@ -8,7 +8,7 @@ trait LoadAllTasks
     // standard tasks
     use Task\Base\loadTasks;
     use Task\Development\loadTasks;
-    use Task\FileSystem\loadTasks;
+    use Task\Filesystem\loadTasks;
     use Task\File\loadTasks;
     use Task\Archive\loadTasks;
     use Task\Vcs\loadTasks;
@@ -32,7 +32,7 @@ trait LoadAllTasks
 
     // shortcuts
     use Task\Base\loadShortcuts;
-    use Task\FileSystem\loadShortcuts;
+    use Task\Filesystem\loadShortcuts;
     use Task\Vcs\loadShortcuts;
 
     /**

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -199,7 +199,7 @@ class Runner
         $container->addServiceProvider(\Robo\Task\Development\loadTasks::getDevelopmentServices());
         $container->addServiceProvider(\Robo\Task\Docker\loadTasks::getDockerServices());
         $container->addServiceProvider(\Robo\Task\File\loadTasks::getFileServices());
-        $container->addServiceProvider(\Robo\Task\FileSystem\loadTasks::getFileSystemServices());
+        $container->addServiceProvider(\Robo\Task\Filesystem\loadTasks::getFilesystemServices());
         $container->addServiceProvider(\Robo\Task\Remote\loadTasks::getRemoteServices());
         $container->addServiceProvider(\Robo\Task\Testing\loadTasks::getTestingServices());
         $container->addServiceProvider(\Robo\Task\Vcs\loadTasks::getVcsServices());

--- a/src/Task/Archive/Extract.php
+++ b/src/Task/Archive/Extract.php
@@ -4,8 +4,8 @@ namespace Robo\Task\Archive;
 
 use Robo\Result;
 use Robo\Task\BaseTask;
-use Robo\Task\FileSystem\FilesystemStack;
-use Robo\Task\FileSystem\DeleteDir;
+use Robo\Task\Filesystem\FilesystemStack;
+use Robo\Task\Filesystem\DeleteDir;
 
 /**
  * Extracts an archive.

--- a/src/Task/Archive/Pack.php
+++ b/src/Task/Archive/Pack.php
@@ -168,19 +168,19 @@ class Pack extends BaseTask implements PrintedInterface
         }
 
         $tar_object = new \Archive_Tar($archiveFile);
-        foreach ($items as $placementLocation => $fileSystemLocation) {
-            $p_remove_dir = $fileSystemLocation;
+        foreach ($items as $placementLocation => $filesystemLocation) {
+            $p_remove_dir = $filesystemLocation;
             $p_add_dir = $placementLocation;
-            if (is_file($fileSystemLocation)) {
-                $p_remove_dir = dirname($fileSystemLocation);
+            if (is_file($filesystemLocation)) {
+                $p_remove_dir = dirname($filesystemLocation);
                 $p_add_dir = dirname($placementLocation);
-                if (basename($fileSystemLocation) != basename($placementLocation)) {
-                    return Result::error($this, "Tar archiver does not support renaming files during extraction; could not add $fileSystemLocation as $placementLocation.");
+                if (basename($filesystemLocation) != basename($placementLocation)) {
+                    return Result::error($this, "Tar archiver does not support renaming files during extraction; could not add $filesystemLocation as $placementLocation.");
                 }
             }
 
-            if (!$tar_object->addModify([$fileSystemLocation], $p_add_dir, $p_remove_dir)) {
-                return Result::error($this, "Could not add $fileSystemLocation to the archive.");
+            if (!$tar_object->addModify([$filesystemLocation], $p_add_dir, $p_remove_dir)) {
+                return Result::error($this, "Could not add $filesystemLocation to the archive.");
             }
         }
 
@@ -205,22 +205,22 @@ class Pack extends BaseTask implements PrintedInterface
 
     protected function addItemsToZip($zip, $items)
     {
-        foreach ($items as $placementLocation => $fileSystemLocation) {
-            if (is_dir($fileSystemLocation)) {
+        foreach ($items as $placementLocation => $filesystemLocation) {
+            if (is_dir($filesystemLocation)) {
                 $finder = new Finder();
-                $finder->files()->in($fileSystemLocation);
+                $finder->files()->in($filesystemLocation);
 
                 foreach ($finder as $file) {
                     if (!$zip->addFile($file->getRealpath(), "{$placementLocation}/{$file->getRelativePathname()}")) {
-                        return Result::error($this, "Could not add directory $fileSystemLocation to the archive; error adding {$file->getRealpath()}.");
+                        return Result::error($this, "Could not add directory $filesystemLocation to the archive; error adding {$file->getRealpath()}.");
                     }
                 }
-            } elseif (is_file($fileSystemLocation)) {
-                if (!$zip->addFile($fileSystemLocation, $placementLocation)) {
-                    return Result::error($this, "Could not add file $fileSystemLocation to the archive.");
+            } elseif (is_file($filesystemLocation)) {
+                if (!$zip->addFile($filesystemLocation, $placementLocation)) {
+                    return Result::error($this, "Could not add file $filesystemLocation to the archive.");
                 }
             } else {
-                return Result::error($this, "Could not find $fileSystemLocation for the archive.");
+                return Result::error($this, "Could not find $filesystemLocation for the archive.");
             }
         }
 

--- a/src/Task/Assets/ImageMinify.php
+++ b/src/Task/Assets/ImageMinify.php
@@ -7,7 +7,7 @@ use Robo\Exception\TaskException;
 use Robo\Task\BaseTask;
 use Robo\Task\Base\Exec;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Filesystem\Filesystem as sfFileSystem;
+use Symfony\Component\Filesystem\Filesystem as sfFilesystem;
 
 /**
  * Minifies images. When the required minifier is not installed on the system
@@ -177,7 +177,7 @@ class ImageMinify extends BaseTask
             ? $this->dirs = $dirs
             : $this->dirs[] = $dirs;
 
-        $this->fs = new sfFileSystem();
+        $this->fs = new sfFilesystem();
 
         // guess the best path for the executables based on __DIR__
         if (($pos = strpos(__DIR__, 'codegyre/robo')) !== false) {

--- a/src/Task/Development/Changelog.php
+++ b/src/Task/Development/Changelog.php
@@ -3,7 +3,7 @@ namespace Robo\Task\Development;
 
 use Robo\Task\BaseTask;
 use Robo\Task\File\Replace;
-use Robo\Task\FileSystem;
+use Robo\Task\Filesystem;
 use Robo\Result;
 use Robo\Task\Development;
 

--- a/src/Task/Development/GenerateMarkdownDoc.php
+++ b/src/Task/Development/GenerateMarkdownDoc.php
@@ -3,7 +3,7 @@ namespace Robo\Task\Development;
 
 use Robo\Task\BaseTask;
 use Robo\Task\File\Write;
-use Robo\Task\FileSystem;
+use Robo\Task\Filesystem;
 use Robo\Result;
 use Robo\Task\Development;
 

--- a/src/Task/Filesystem/BaseDir.php
+++ b/src/Task/Filesystem/BaseDir.php
@@ -1,8 +1,8 @@
 <?php
-namespace Robo\Task\FileSystem;
+namespace Robo\Task\Filesystem;
 
 use Robo\Task\BaseTask;
-use Symfony\Component\Filesystem\Filesystem as sfFileSystem;
+use Symfony\Component\Filesystem\Filesystem as sfFilesystem;
 
 abstract class BaseDir extends BaseTask
 {
@@ -16,6 +16,6 @@ abstract class BaseDir extends BaseTask
             ? $this->dirs = $dirs
             : $this->dirs[] = $dirs;
 
-        $this->fs = new sfFileSystem();
+        $this->fs = new sfFilesystem();
     }
 }

--- a/src/Task/Filesystem/CleanDir.php
+++ b/src/Task/Filesystem/CleanDir.php
@@ -1,5 +1,5 @@
 <?php
-namespace Robo\Task\FileSystem;
+namespace Robo\Task\Filesystem;
 
 use Robo\Common\ResourceExistenceChecker;
 use Robo\Result;

--- a/src/Task/Filesystem/CopyDir.php
+++ b/src/Task/Filesystem/CopyDir.php
@@ -1,5 +1,5 @@
 <?php
-namespace Robo\Task\FileSystem;
+namespace Robo\Task\Filesystem;
 
 use Robo\Common\ResourceExistenceChecker;
 use Robo\Result;

--- a/src/Task/Filesystem/DeleteDir.php
+++ b/src/Task/Filesystem/DeleteDir.php
@@ -1,5 +1,5 @@
 <?php
-namespace Robo\Task\FileSystem;
+namespace Robo\Task\Filesystem;
 
 use Robo\Common\ResourceExistenceChecker;
 use Robo\Result;

--- a/src/Task/Filesystem/FilesystemStack.php
+++ b/src/Task/Filesystem/FilesystemStack.php
@@ -1,19 +1,19 @@
 <?php
-namespace Robo\Task\FileSystem;
+namespace Robo\Task\Filesystem;
 
 use Robo\Result;
 use Robo\Task\StackBasedTask;
-use Symfony\Component\Filesystem\Filesystem as sfFileSystem;
+use Symfony\Component\Filesystem\Filesystem as sfFilesystem;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 
 /**
- * Wrapper for [Symfony FileSystem](http://symfony.com/doc/current/components/filesystem.html) Component.
+ * Wrapper for [Symfony Filesystem](http://symfony.com/doc/current/components/filesystem.html) Component.
  * Comands are executed in stack and can be stopped on first fail with `stopOnFail` option.
  *
  * ``` php
  * <?php
- * $this->taskFileSystemStack()
+ * $this->taskFilesystemStack()
  *      ->mkdir('logs')
  *      ->touch('logs/.gitignore')
  *      ->chgrp('www', 'www-data')
@@ -44,7 +44,7 @@ class FilesystemStack extends StackBasedTask
 
     public function __construct()
     {
-        $this->fs = new sfFileSystem();
+        $this->fs = new sfFilesystem();
     }
 
     protected function getDelegate()

--- a/src/Task/Filesystem/FlattenDir.php
+++ b/src/Task/Filesystem/FlattenDir.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Robo\Task\FileSystem;
+namespace Robo\Task\Filesystem;
 
 use Robo\Result;
 use Robo\Exception\TaskException;

--- a/src/Task/Filesystem/MirrorDir.php
+++ b/src/Task/Filesystem/MirrorDir.php
@@ -1,5 +1,5 @@
 <?php
-namespace Robo\Task\FileSystem;
+namespace Robo\Task\Filesystem;
 
 use Robo\Result;
 

--- a/src/Task/Filesystem/TmpDir.php
+++ b/src/Task/Filesystem/TmpDir.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Robo\Task\FileSystem;
+namespace Robo\Task\Filesystem;
 
 use Robo\Result;
 use Robo\Collection\Collection;
@@ -18,7 +18,7 @@ use Robo\Contract\CompletionInterface;
  * // Note that in this example, everything is deleted at
  * // the end of $collection->run().
  * $tmpPath = $this->taskTmpDir()->addToCollection($collection)->getPath();
- * $this->taskFileSystemStack()
+ * $this->taskFilesystemStack()
  *           ->mkdir("$tmpPath/log")
  *           ->touch("$tmpPath/log/error.txt")
  *           ->addToCollection($collection);

--- a/src/Task/Filesystem/loadShortcuts.php
+++ b/src/Task/Filesystem/loadShortcuts.php
@@ -1,5 +1,5 @@
 <?php
-namespace Robo\Task\FileSystem;
+namespace Robo\Task\Filesystem;
 
 use Robo\Collection\Temporary;
 
@@ -50,7 +50,7 @@ trait loadShortcuts
      */
     protected function _rename($from, $to)
     {
-        return $this->getContainer()->get('taskFileSystemStack')->rename($from, $to)->run();
+        return $this->getContainer()->get('taskFilesystemStack')->rename($from, $to)->run();
     }
 
     /**
@@ -59,7 +59,7 @@ trait loadShortcuts
      */
     protected function _mkdir($dir)
     {
-        return $this->getContainer()->get('taskFileSystemStack')->mkdir($dir)->run();
+        return $this->getContainer()->get('taskFilesystemStack')->mkdir($dir)->run();
     }
 
     /**
@@ -78,7 +78,7 @@ trait loadShortcuts
      */
     protected function _touch($file)
     {
-        return $this->getContainer()->get('taskFileSystemStack')->touch($file)->run();
+        return $this->getContainer()->get('taskFilesystemStack')->touch($file)->run();
     }
 
     /**
@@ -87,7 +87,7 @@ trait loadShortcuts
      */
     protected function _remove($file)
     {
-        return $this->getContainer()->get('taskFileSystemStack')->remove($file)->run();
+        return $this->getContainer()->get('taskFilesystemStack')->remove($file)->run();
     }
 
     /**
@@ -97,7 +97,7 @@ trait loadShortcuts
      */
     protected function _chgrp($file, $group)
     {
-        return $this->getContainer()->get('taskFileSystemStack')->chgrp($file, $group)->run();
+        return $this->getContainer()->get('taskFilesystemStack')->chgrp($file, $group)->run();
     }
 
     /**
@@ -109,7 +109,7 @@ trait loadShortcuts
      */
     protected function _chmod($file, $permissions, $umask = 0000, $recursive = false)
     {
-        return $this->getContainer()->get('taskFileSystemStack')->chmod($file, $permissions, $umask, $recursive)->run();
+        return $this->getContainer()->get('taskFilesystemStack')->chmod($file, $permissions, $umask, $recursive)->run();
     }
 
     /**
@@ -119,7 +119,7 @@ trait loadShortcuts
      */
     protected function _symlink($from, $to)
     {
-        return $this->getContainer()->get('taskFileSystemStack')->symlink($from, $to)->run();
+        return $this->getContainer()->get('taskFilesystemStack')->symlink($from, $to)->run();
     }
 
     /**
@@ -129,7 +129,7 @@ trait loadShortcuts
      */
     protected function _copy($from, $to)
     {
-        return $this->getContainer()->get('taskFileSystemStack')->copy($from, $to)->run();
+        return $this->getContainer()->get('taskFilesystemStack')->copy($from, $to)->run();
     }
 
     /**

--- a/src/Task/Filesystem/loadTasks.php
+++ b/src/Task/Filesystem/loadTasks.php
@@ -1,5 +1,5 @@
 <?php
-namespace Robo\Task\FileSystem;
+namespace Robo\Task\Filesystem;
 
 use Robo\Collection\Temporary;
 use Robo\Container\SimpleServiceProvider;
@@ -9,7 +9,7 @@ trait loadTasks
     /**
      * Return services.
      */
-    public static function getFileSystemServices()
+    public static function getFilesystemServices()
     {
         return new SimpleServiceProvider(
             [


### PR DESCRIPTION
Existing code sometimes uses 'Filesystem' and sometimes uses 'FileSystem'; this is a source of confusion and bugs.  See #331. Symfony uses Symfony/Component/Filesystem; this PR switches to lowercase "system" everywhere.

This may cause some short-term pain with folks upgrading from 0.6.x, but resolving the ambiguity will be better in the long run, I think.